### PR TITLE
Fixing TraceIDHeader and replace deprecated func

### DIFF
--- a/internal/platform/trace/trace.go
+++ b/internal/platform/trace/trace.go
@@ -25,8 +25,7 @@ func WithSpanContext(ctx context.Context, name string, spanContext string) (cont
 			return ctx, span
 		}
 
-		span := trace.NewSpanWithRemoteParent(name, sc, trace.StartOptions{})
-		ctx := trace.WithSpan(ctx, span)
+		ctx, span := trace.StartSpanWithRemoteParent(ctx, name, sc)
 		return ctx, span
 	}
 

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -78,10 +78,7 @@ func (a *App) Handle(verb, path string, handler Handler, mw ...Middleware) {
 		// Set the parent span on the outgoing requests before any other header to
 		// ensure that the trace is ALWAYS added to the request regardless of
 		// any error occuring or not.
-		data, err := trace.MarshalSpanContext(span.SpanContext())
-		if err == nil {
-			w.Header().Set(TraceIDHeader, string(data))
-		}
+		w.Header().Set(TraceIDHeader, v.TraceID)
 
 		// Call the wrapped handler functions.
 		if err := handler(ctx, a.log, w, r, params); err != nil {


### PR DESCRIPTION
I think TraceIDHeader should set only trace id and it is returning extra info and value on diff format 

![screen shot 2018-08-09 at 9 51 51 am](https://user-images.githubusercontent.com/6372846/43903219-eeb4c0e8-9bb9-11e8-8a9a-2f200ac60e26.png)

Looks like NewSpanWithRemoteParent func has been deprecated and recommend using StartSpanWithRemoteParent.
