### PR TITLE
Refactor/http status errors

### DIFF
--- a/internal/platform/web/errors.go
+++ b/internal/platform/web/errors.go
@@ -1,20 +1,25 @@
 package web
 
 import (
+	"fmt"
 	"net/http"
 )
 
 type statusError struct {
-	error
+	err    error
 	Status int
 }
 
+func (se *statusError) Error() string {
+	return fmt.Sprintf("http status %v: %s", se.Status, se.err)
+}
+
 func ErrorWithStatus(err error, status int) error {
-	return statusError{err, status}
+	return &statusError{err, status}
 }
 
 func StatusFromError(err error) int {
-	serr, ok := err.(statusError)
+	serr, ok := err.(*statusError)
 	if !ok {
 		return http.StatusInternalServerError
 	}

--- a/internal/platform/web/errors.go
+++ b/internal/platform/web/errors.go
@@ -1,0 +1,28 @@
+package web
+
+import "net/http"
+
+type HTTPStatuser interface {
+	HTTPStatus() int
+}
+
+type statusError struct {
+	error
+	status int
+}
+
+func (e statusError) HTTPStatus() int {
+	return e.status
+}
+
+func ErrorWithStatus(err error, status int) error {
+	return statusError{err, status}
+}
+
+func StatusFromError(err error) int {
+	inf, ok := err.(HTTPStatuser)
+	if !ok {
+		return http.StatusInternalServerError
+	}
+	return inf.HTTPStatus()
+}

--- a/internal/platform/web/errors.go
+++ b/internal/platform/web/errors.go
@@ -1,18 +1,12 @@
 package web
 
-import "net/http"
-
-type HTTPStatuser interface {
-	HTTPStatus() int
-}
+import (
+	"net/http"
+)
 
 type statusError struct {
 	error
-	status int
-}
-
-func (e statusError) HTTPStatus() int {
-	return e.status
+	Status int
 }
 
 func ErrorWithStatus(err error, status int) error {
@@ -20,9 +14,9 @@ func ErrorWithStatus(err error, status int) error {
 }
 
 func StatusFromError(err error) int {
-	inf, ok := err.(HTTPStatuser)
+	serr, ok := err.(statusError)
 	if !ok {
 		return http.StatusInternalServerError
 	}
-	return inf.HTTPStatus()
+	return serr.Status
 }

--- a/internal/platform/web/errors_test.go
+++ b/internal/platform/web/errors_test.go
@@ -1,0 +1,38 @@
+package web_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ardanlabs/service/internal/platform/web"
+	"github.com/pkg/errors"
+)
+
+func TestHTTPStatuser(t *testing.T) {
+	cases := []struct {
+		Err            error
+		ExpectedStatus int
+	}{
+		{
+			Err:            errors.New("utoh"),
+			ExpectedStatus: http.StatusInternalServerError,
+		},
+		{
+			Err:            web.ErrorWithStatus(errors.New("its not my fault!"), http.StatusBadRequest),
+			ExpectedStatus: http.StatusBadRequest,
+		},
+		{
+			// NOTE: If we wrap the error, we lose the status.
+			// TODO: Is this the desired behavior?
+			Err:            errors.Wrap(web.ErrorWithStatus(errors.New("its not my fault!"), http.StatusBadRequest), "more info"),
+			ExpectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for i, c := range cases {
+		s := web.StatusFromError(c.Err)
+		if exp, got := c.ExpectedStatus, s; exp != got {
+			t.Fatalf("[%v] expected status %v, got %v", i, exp, got)
+		}
+	}
+}

--- a/internal/platform/web/errors_test.go
+++ b/internal/platform/web/errors_test.go
@@ -12,20 +12,24 @@ func TestStatusError(t *testing.T) {
 	cases := []struct {
 		Err            error
 		ExpectedStatus int
+		ExpectedString string
 	}{
 		{
 			Err:            errors.New("utoh"),
 			ExpectedStatus: http.StatusInternalServerError,
+			ExpectedString: "utoh",
 		},
 		{
 			Err:            web.ErrorWithStatus(errors.New("its not my fault!"), http.StatusBadRequest),
 			ExpectedStatus: http.StatusBadRequest,
+			ExpectedString: "http status 400: its not my fault!",
 		},
 		{
 			// NOTE: If we wrap the error, we lose the status.
 			// TODO: Is this the desired behavior?
 			Err:            errors.Wrap(web.ErrorWithStatus(errors.New("its not my fault!"), http.StatusBadRequest), "more info"),
 			ExpectedStatus: http.StatusInternalServerError,
+			ExpectedString: "more info: http status 400: its not my fault!",
 		},
 	}
 
@@ -33,6 +37,10 @@ func TestStatusError(t *testing.T) {
 		s := web.StatusFromError(c.Err)
 		if exp, got := c.ExpectedStatus, s; exp != got {
 			t.Fatalf("[%v] expected status %v, got %v", i, exp, got)
+		}
+
+		if exp, got := c.ExpectedString, c.Err.Error(); exp != got {
+			t.Fatalf("[%v] expected error string %q, got %q", i, exp, got)
 		}
 	}
 }

--- a/internal/platform/web/errors_test.go
+++ b/internal/platform/web/errors_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestHTTPStatuser(t *testing.T) {
+func TestStatusError(t *testing.T) {
 	cases := []struct {
 		Err            error
 		ExpectedStatus int

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -39,40 +39,7 @@ type JSONError struct {
 
 // Error handles all error responses for the API.
 func Error(cxt context.Context, log *log.Logger, w http.ResponseWriter, err error) {
-	switch errors.Cause(err) {
-	case ErrNotHealthy:
-		RespondError(cxt, log, w, err, http.StatusInternalServerError)
-		return
-
-	case ErrNotFound:
-		RespondError(cxt, log, w, err, http.StatusNotFound)
-		return
-
-	case ErrValidation, ErrInvalidID:
-		RespondError(cxt, log, w, err, http.StatusBadRequest)
-		return
-
-	case ErrUnauthorized:
-		RespondError(cxt, log, w, err, http.StatusUnauthorized)
-		return
-
-	case ErrForbidden:
-		RespondError(cxt, log, w, err, http.StatusForbidden)
-		return
-	}
-
-	switch e := errors.Cause(err).(type) {
-	case InvalidError:
-		v := JSONError{
-			Error:  "field validation failure",
-			Fields: e,
-		}
-
-		Respond(cxt, log, w, v, http.StatusBadRequest)
-		return
-	}
-
-	RespondError(cxt, log, w, err, http.StatusInternalServerError)
+	RespondError(cxt, log, w, err, StatusFromError(err))
 }
 
 // RespondError sends JSON describing the error

--- a/internal/platform/web/validation.go
+++ b/internal/platform/web/validation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	validator "gopkg.in/go-playground/validator.v8"
 )
@@ -36,7 +37,9 @@ func (err InvalidError) Error() string {
 // fields to verify the value is in a proper state.
 func Unmarshal(r io.Reader, v interface{}) error {
 	if err := json.NewDecoder(r).Decode(v); err != nil {
-		return err
+		// TODO: Remove this comment:
+		// Here is an example of how the status-wrapper might be used.
+		return ErrorWithStatus(err, http.StatusUnprocessableEntity)
 	}
 
 	var inv InvalidError


### PR DESCRIPTION
Idea: Wrap errors with a status rather than defining `web.ErrNotFound`, etc.

Note: Not a complete PR currently, just a discussion starter right now.