### PR TITLE
Update makefile for build, add admin command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+private.pem

--- a/README.md
+++ b/README.md
@@ -119,6 +119,36 @@ The service provides record keeping for someone running a multi-family garage sa
 
 <!--(Diagram generated with draw.io using `models.xml` file)-->
 
+### Making Requests
+
+#### Initial User
+
+To make a request to the service you must have an authenticated user. Users can be created with the API but an initial admin user must first be created. While the service is running you can create the initial user with the command `make admin`
+
+```
+$ make admin
+```
+
+This will create a user with email `admin@example.com` and password `gophers`.
+
+#### Authenticating
+
+Before any authenticated requests can be sent you must acquire an auth token. Make a request using HTTP Basic auth with your email and password to get the token.
+
+```
+$ curl --user "admin@example.com:gophers" http://localhost:3000/v1/users/token
+```
+
+I suggest putting the resulting token in an environment variable like `$TOKEN`.
+
+#### Authenticated Requests
+
+To make authenticated requests put the token in the `Authorization` header with the `Bearer ` prefix.
+
+```
+$ curl -H "Authorization: Bearer ${TOKEN}" http://localhost:3000/v1/users
+```
+
 ## What's Next
 
 We are in the process of writing more documentation about this code. Classes are being finalized as part of the Ultimate series.

--- a/cmd/sales-admin/main.go
+++ b/cmd/sales-admin/main.go
@@ -1,0 +1,137 @@
+// This program performs administrative tasks for the garage sale service.
+//
+// Run it with --cmd keygen or --cmd useradd
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/ardanlabs/service/internal/platform/auth"
+	"github.com/ardanlabs/service/internal/platform/db"
+	"github.com/ardanlabs/service/internal/platform/flag"
+	"github.com/ardanlabs/service/internal/user"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/pkg/errors"
+)
+
+func main() {
+
+	// =========================================================================
+	// Logging
+
+	log := log.New(os.Stdout, "sales-admin : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
+
+	// =========================================================================
+	// Configuration
+
+	var cfg struct {
+		CMD string `envconfig:"CMD"`
+		DB  struct {
+			DialTimeout time.Duration `default:"5s" envconfig:"DIAL_TIMEOUT"`
+			Host        string        `default:"localhost:27017/gotraining" envconfig:"HOST"`
+		}
+		Auth struct {
+			PrivateKeyFile string `default:"private.pem" envconfig:"PRIVATE_KEY_FILE"`
+		}
+		User struct {
+			Email    string
+			Password string
+		}
+	}
+
+	if err := envconfig.Process("SALES", &cfg); err != nil {
+		log.Fatalf("main : Parsing Config : %v", err)
+	}
+
+	if err := flag.Process(&cfg); err != nil {
+		if err != flag.ErrHelp {
+			log.Fatalf("main : Parsing Command Line : %v", err)
+		}
+		return // We displayed help.
+	}
+
+	var err error
+	switch cfg.CMD {
+	case "keygen":
+		err = keygen(cfg.Auth.PrivateKeyFile)
+	case "useradd":
+		err = useradd(cfg.DB.Host, cfg.DB.DialTimeout, cfg.User.Email, cfg.User.Password)
+	default:
+		err = errors.New("Must provide --cmd keygen or --cmd useradd")
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// keygen creates an x509 private key for signing auth tokens.
+func keygen(path string) error {
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return errors.Wrap(err, "generating keys")
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return errors.Wrap(err, "creating private file")
+	}
+
+	block := pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+
+	if err := pem.Encode(file, &block); err != nil {
+		return errors.Wrap(err, "encoding to private file")
+	}
+
+	if err := file.Close(); err != nil {
+		return errors.Wrap(err, "closing private file")
+	}
+
+	return nil
+}
+
+func useradd(dbHost string, dbTimeout time.Duration, email, pass string) error {
+
+	dbConn, err := db.New(dbHost, dbTimeout)
+	if err != nil {
+		return err
+	}
+	defer dbConn.Close()
+
+	if email == "" {
+		return errors.New("Must provide --user_email")
+	}
+	if pass == "" {
+		return errors.New("Must provide --user_password or set the env var SALES_USER_PASSWORD")
+	}
+
+	ctx := context.Background()
+
+	newU := user.NewUser{
+		Email:           email,
+		Password:        pass,
+		PasswordConfirm: pass,
+		Roles:           []string{auth.RoleAdmin, auth.RoleUser},
+	}
+
+	usr, err := user.Create(ctx, dbConn, &newU, time.Now())
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("User created with id: %v\n", usr.ID.Hex())
+	return nil
+}

--- a/cmd/sales-api/handlers/routes.go
+++ b/cmd/sales-api/handlers/routes.go
@@ -18,7 +18,6 @@ func API(log *log.Logger, masterDB *db.DB, authenticator *auth.Authenticator) ht
 		Authenticator: authenticator,
 	}
 
-	// TODO(jlw) Figure out why the order of these was reversed and maybe reverse it back.
 	app := web.New(log, mid.RequestLogger, mid.Metrics, mid.ErrorHandler)
 
 	// Register health check endpoint. This route is not authenticated.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,10 +22,6 @@ services:
 
   # This is the core CRUD based service.
   sales-api:
-    build:
-      context: .
-      args:
-        packagename: sales-api
     container_name: sales-api
     networks:
       - shared-network
@@ -33,18 +29,15 @@ services:
     ports:
       - 3000:3000 # CRUD API
       - 4000:4000 # DEBUG API
-    # environment:
-      # - SALES_DB_HOST=docker.for.mac.localhost:27017
+    volumes:
+      - ${PWD}/private.pem:/app/private.pem
+    environment:
+      - SALES_AUTH_KEY_ID=1
       # - SALES_DB_HOST=got:got2015@ds039441.mongolab.com:39441/gotraining
       # - GODEBUG=gctrace=1
 
   # This sidecar publishes metrics to the console by default.
   metrics:
-    build:
-      context: .
-      args:
-        packagename: metrics
-        packageprefix: sidecar/
     container_name: metrics
     networks:
       - shared-network
@@ -55,11 +48,6 @@ services:
 
   # This sidecar publishes tracing to the console by default.
   tracer:
-    build:
-      context: .
-      args:
-        packagename: tracer
-        packageprefix: sidecar/
     container_name: tracer
     networks:
       - shared-network

--- a/dockerfile
+++ b/dockerfile
@@ -2,12 +2,13 @@
 
 FROM golang:1.10.3 as build
 ENV CGO_ENABLED 0
-ARG packagename
-ARG packageprefix
+ARG VCS_REF
+ARG PACKAGE_NAME
+ARG PACKAGE_PREFIX
 RUN mkdir -p /go/src/github.com/ardanlabs/service
 COPY . /go/src/github.com/ardanlabs/service
-WORKDIR /go/src/github.com/ardanlabs/service/cmd/${packageprefix}${packagename}
-RUN go build -ldflags "-s -w -X main.build=$(git rev-parse HEAD)" -a -tags netgo
+WORKDIR /go/src/github.com/ardanlabs/service/cmd/${PACKAGE_PREFIX}${PACKAGE_NAME}
+RUN go build -ldflags "-s -w -X main.build=${VCS_REF}" -a -tags netgo
 
 
 # Run the Go Binary in Alpine.
@@ -15,16 +16,15 @@ RUN go build -ldflags "-s -w -X main.build=$(git rev-parse HEAD)" -a -tags netgo
 FROM alpine:3.7
 ARG BUILD_DATE
 ARG VCS_REF
-ARG packagename
-ARG packageprefix
-EXPOSE 3001
-EXPOSE 4001
-COPY --from=build /go/src/github.com/ardanlabs/service/cmd/${packageprefix}${packagename}/${packagename} /bin/package
-ENTRYPOINT /bin/package
+ARG PACKAGE_NAME
+ARG PACKAGE_PREFIX
+COPY --from=build /go/src/github.com/ardanlabs/service/cmd/${PACKAGE_PREFIX}${PACKAGE_NAME}/${PACKAGE_NAME} /app/main
+WORKDIR /app
+CMD /app/main
 
-LABEL org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.title=${packagename} \
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="${PACKAGE_NAME}" \
       org.opencontainers.image.authors="William Kennedy <bill@ardanlabs.com>" \
-      org.opencontainers.image.source="https://github.com/ardanlabs/service/cmd/${packageprefix}${packagename}" \
-      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.source="https://github.com/ardanlabs/service/cmd/${PACKAGE_PREFIX}${PACKAGE_NAME}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.vendor="Ardan Labs"

--- a/makefile
+++ b/makefile
@@ -1,22 +1,27 @@
 SHELL := /bin/bash
 
-all: sales-api metrics tracer
+all: keys sales-api metrics tracer
+
+keys:
+	go run ./cmd/sales-admin/main.go --cmd keygen
+
+admin:
+	go run ./cmd/sales-admin/main.go --cmd useradd --user_email admin@example.com --user_password gophers
 
 sales-api:
-	cd "$$GOPATH/src/github.com/ardanlabs/service"
 	docker build \
 		-t sales-api-amd64:1.0 \
-		-f dockerfile.sales-api \
+		--build-arg PACKAGE_NAME=sales-api \
 		--build-arg VCS_REF=`git rev-parse HEAD` \
 		--build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
 		.
 	docker system prune -f
 
 metrics:
-	cd "$$GOPATH/src/github.com/ardanlabs/service"
 	docker build \
 		-t metrics-amd64:1.0 \
-		-f dockerfile.metrics \
+		--build-arg PACKAGE_NAME=metrics \
+		--build-arg PACKAGE_PREFIX=sidecar/ \
 		--build-arg VCS_REF=`git rev-parse HEAD` \
 		--build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
 		.
@@ -26,7 +31,8 @@ tracer:
 	cd "$$GOPATH/src/github.com/ardanlabs/service"
 	docker build \
 		-t tracer-amd64:1.0 \
-		-f dockerfile.tracer \
+		--build-arg PACKAGE_NAME=tracer \
+		--build-arg PACKAGE_PREFIX=sidecar/ \
 		--build-arg VCS_REF=`git rev-parse HEAD` \
 		--build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
 		.


### PR DESCRIPTION
This PR does a few final things to ensure the service is runnable.

1. Updates the makefile to work with the single-dockerfile approach. Previously `docker-compose up` knew how to build the images but now it doesn't.

2. Adds a second command `sales-admin` which holds two administrative scripts for running the service.
  - `--cmd keygen` generates a private key for signing auth tokens. This is preferable over using `openssl` or something on the command line because not everyone has that installed.
  - `--cmd useradd` which creates an initial admin user. If you use `make admin` it creates a user with email `admin@example.com` and password `gophers`. If you want to use something else you can run it yourself like

```
go run ./cmd/sales-admin/main.go --cmd useradd --user_email jacob@ardanlabs.com --user_password PASSWORD
```

3. This change also mounts the private key inside the running container. I wanted to get this from a config service or something but whatever.

4. Fixes getting the git build information inside the main binary