### PR TITLE
Unmarshal - return error if input fields not match

### DIFF
--- a/internal/platform/web/validation.go
+++ b/internal/platform/web/validation.go
@@ -35,7 +35,11 @@ func (err InvalidError) Error() string {
 // Unmarshal decodes the input to the struct type and checks the
 // fields to verify the value is in a proper state.
 func Unmarshal(r io.Reader, v interface{}) error {
-	if err := json.NewDecoder(r).Decode(v); err != nil {
+
+	decode := json.NewDecoder(r)
+	decode.DisallowUnknownFields()
+
+	if err := decode.Decode(v); err != nil {
 		return err
 	}
 

--- a/internal/platform/web/validation.go
+++ b/internal/platform/web/validation.go
@@ -35,10 +35,8 @@ func (err InvalidError) Error() string {
 // Unmarshal decodes the input to the struct type and checks the
 // fields to verify the value is in a proper state.
 func Unmarshal(r io.Reader, v interface{}) error {
-
 	decode := json.NewDecoder(r)
 	decode.DisallowUnknownFields()
-
 	if err := decode.Decode(v); err != nil {
 		return err
 	}


### PR DESCRIPTION
Unmarshal not returning any error if field name incorrect or not available. Go version 1.10 added a new method DisallowUnknownFields which we can use to return error for unknown JSON fields.