### PR TITLE
Use the simple http.ListenAndServe for debug services

### DIFF
--- a/cmd/sales-api/main.go
+++ b/cmd/sales-api/main.go
@@ -157,24 +157,14 @@ func main() {
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	// =========================================================================
-	// Start Debug Service
-
+	// Start Debug Service. Not concerned with shutting this down when the
+	// application is being shutdown.
+	//
 	// /debug/vars - Added to the default mux by the expvars package.
 	// /debug/pprof - Added to the default mux by the net/http/pprof package.
-
-	debug := http.Server{
-		Addr:           cfg.Web.DebugHost,
-		Handler:        http.DefaultServeMux,
-		ReadTimeout:    cfg.Web.ReadTimeout,
-		WriteTimeout:   cfg.Web.WriteTimeout,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	// Not concerned with shutting this down when the
-	// application is being shutdown.
 	go func() {
 		log.Printf("main : Debug Listening %s", cfg.Web.DebugHost)
-		log.Printf("main : Debug Listener closed : %v", debug.ListenAndServe())
+		log.Printf("main : Debug Listener closed : %v", http.ListenAndServe(cfg.Web.DebugHost, http.DefaultServeMux))
 	}()
 
 	// =========================================================================

--- a/cmd/sidecar/metrics/main.go
+++ b/cmd/sidecar/metrics/main.go
@@ -61,23 +61,13 @@ func main() {
 	log.Printf("config : %v\n", string(cfgJSON))
 
 	// =========================================================================
-	// Start Debug Service
-
-	// /debug/pprof - Added to the default mux by the net/http/pprof package.
-
-	debug := http.Server{
-		Addr:           cfg.Web.DebugHost,
-		Handler:        http.DefaultServeMux,
-		ReadTimeout:    cfg.Web.ReadTimeout,
-		WriteTimeout:   cfg.Web.WriteTimeout,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	// Not concerned with shutting this down when the
+	// Start Debug Service. Not concerned with shutting this down when the
 	// application is being shutdown.
+	//
+	// /debug/pprof - Added to the default mux by the net/http/pprof package.
 	go func() {
 		log.Printf("main : Debug Listening %s", cfg.Web.DebugHost)
-		log.Printf("main : Debug Listener closed : %v", debug.ListenAndServe())
+		log.Printf("main : Debug Listener closed : %v", http.ListenAndServe(cfg.Web.DebugHost, http.DefaultServeMux))
 	}()
 
 	// =========================================================================

--- a/cmd/sidecar/tracer/main.go
+++ b/cmd/sidecar/tracer/main.go
@@ -50,23 +50,13 @@ func main() {
 	log.Printf("config : %v\n", string(cfgJSON))
 
 	// =========================================================================
-	// Start Debug Service
-
-	// /debug/pprof - Added to the default mux by the net/http/pprof package.
-
-	debug := http.Server{
-		Addr:           cfg.Web.DebugHost,
-		Handler:        http.DefaultServeMux,
-		ReadTimeout:    cfg.Web.ReadTimeout,
-		WriteTimeout:   cfg.Web.WriteTimeout,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	// Not concerned with shutting this down when the
+	// Start Debug Service. Not concerned with shutting this down when the
 	// application is being shutdown.
+	//
+	// /debug/pprof - Added to the default mux by the net/http/pprof package.
 	go func() {
 		log.Printf("main : Debug Listening %s", cfg.Web.DebugHost)
-		log.Printf("main : Debug Listener closed : %v", debug.ListenAndServe())
+		log.Printf("main : Debug Listener closed : %v", http.ListenAndServe(cfg.Web.DebugHost, http.DefaultServeMux))
 	}()
 
 	// =========================================================================


### PR DESCRIPTION
We already aren't using graceful shutdown for these services as they are internal only. Similarly we don't need custom timeouts etc.