### PR TITLE
Apply middleware so they are executed in the order they are listed

### DIFF
--- a/cmd/sales-api/handlers/routes.go
+++ b/cmd/sales-api/handlers/routes.go
@@ -13,7 +13,7 @@ import (
 
 // API returns a handler for a set of routes.
 func API(shutdown chan os.Signal, log *log.Logger, masterDB *db.DB, authenticator *auth.Authenticator) http.Handler {
-	app := web.New(shutdown, log, mid.ErrorHandler, mid.Metrics, mid.RequestLogger)
+	app := web.New(shutdown, log, mid.RequestLogger, mid.Metrics, mid.ErrorHandler)
 
 	// authmw is used for authentication/authorization middleware.
 	authmw := mid.Auth{
@@ -31,11 +31,11 @@ func API(shutdown chan os.Signal, log *log.Logger, masterDB *db.DB, authenticato
 		MasterDB:       masterDB,
 		TokenGenerator: authenticator,
 	}
-	app.Handle("GET", "/v1/users", u.List, authmw.HasRole(auth.RoleAdmin), authmw.Authenticate)
-	app.Handle("POST", "/v1/users", u.Create, authmw.HasRole(auth.RoleAdmin), authmw.Authenticate)
+	app.Handle("GET", "/v1/users", u.List, authmw.Authenticate, authmw.HasRole(auth.RoleAdmin))
+	app.Handle("POST", "/v1/users", u.Create, authmw.Authenticate, authmw.HasRole(auth.RoleAdmin))
 	app.Handle("GET", "/v1/users/:id", u.Retrieve, authmw.Authenticate)
-	app.Handle("PUT", "/v1/users/:id", u.Update, authmw.HasRole(auth.RoleAdmin), authmw.Authenticate)
-	app.Handle("DELETE", "/v1/users/:id", u.Delete, authmw.HasRole(auth.RoleAdmin), authmw.Authenticate)
+	app.Handle("PUT", "/v1/users/:id", u.Update, authmw.Authenticate, authmw.HasRole(auth.RoleAdmin))
+	app.Handle("DELETE", "/v1/users/:id", u.Delete, authmw.Authenticate, authmw.HasRole(auth.RoleAdmin))
 
 	// This route is not authenticated
 	app.Handle("GET", "/v1/users/token", u.Token)

--- a/internal/platform/web/middleware.go
+++ b/internal/platform/web/middleware.go
@@ -1,14 +1,20 @@
 package web
 
-// A Middleware is a type that wraps a handler to remove boilerplate or other
-// concerns not direct to any given Handler.
+// Middleware is a function designed to run some code before and/or after
+// another Handler. It is designed to remove boilerplate or other concerns not
+// direct to any given Handler.
 type Middleware func(Handler) Handler
 
-// wrapMiddleware wraps a handler with some middleware.
-func wrapMiddleware(handler Handler, mw []Middleware) Handler {
+// wrapMiddleware creates a new handler by wrapping middleware around a final
+// handler. The middlewares' Handlers will be executed by requests in the order
+// they are provided.
+func wrapMiddleware(mw []Middleware, handler Handler) Handler {
 
-	// Wrap with our group specific middleware.
-	for _, h := range mw {
+	// Loop backwards through the middleware invoking each one. Replace the
+	// handler with the new wrapped handler. Looping backwards ensures that the
+	// first middleware of the slice is the first to be executed by requests.
+	for i := len(mw) - 1; i >= 0; i-- {
+		h := mw[i]
 		if h != nil {
 			handler = h(handler)
 		}

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -62,9 +62,11 @@ func (a *App) SignalShutdown() {
 // pair, this makes for really easy, convenient routing.
 func (a *App) Handle(verb, path string, handler Handler, mw ...Middleware) {
 
-	// Wrap up the application-wide first, this will call the first function
-	// of each middleware which will return a function of type Handler.
-	handler = wrapMiddleware(wrapMiddleware(handler, mw), a.mw)
+	// First wrap handler specific middleware around this handler.
+	handler = wrapMiddleware(mw, handler)
+
+	// Add the application's general middleware to the handler chain.
+	handler = wrapMiddleware(a.mw, handler)
 
 	// The function to execute for each request.
 	h := func(w http.ResponseWriter, r *http.Request, params map[string]string) {


### PR DESCRIPTION
Ranging over middleware from beginning to end when building handler chains has the effect of *wrapping* them in the order they are listed but it means the resulting middleware handlers are executed in *reverse* of the order they are shown in the code. This always confused me especially when we have middleware that must be ran after another such as the auth `HasRole` mw which must be ran after the `Authenticate` mw. In the route listing we have to put the `HasRole` first to ensure it is executed after `Authenticate`.

I changed `wrapMiddleware` to loop backwards through the list and wrap in that order. This means when a request comes in then the middleware handlers will be first encountered in the order they are listed in source code.

Also as a minor change I swapped the arguments of `wrapMiddleware`. It was

```
wrapMiddleware(h Handler, mw []Middleware) Handler
```
and is now
```
wrapMiddleware(mw []Middleware, h Handler) Handler
```

To me this reads as "please wrap these middleware around this handler"

Second minor change is the line in `web.go` where we invoke `wrapMiddleware`. I broke it out to two separate lines to make it easier to follow.