### PR TITLE
Use a single type to hold state for all middleware

### DIFF
--- a/cmd/sidecar/tracer/handlers/routes.go
+++ b/cmd/sidecar/tracer/handlers/routes.go
@@ -12,7 +12,10 @@ import (
 
 // API returns a handler for a set of routes.
 func API(shutdown chan os.Signal, log *log.Logger, zipkinHost string, apiHost string) http.Handler {
-	app := web.New(shutdown, log, mid.RequestLogger, mid.ErrorHandler)
+
+	mw := mid.Middleware{}
+
+	app := web.New(shutdown, log, mw.Logger, mw.Errors)
 
 	z := NewZipkin(zipkinHost, apiHost, time.Second)
 	app.Handle("POST", "/v1/publish", z.Publish)

--- a/internal/mid/errors.go
+++ b/internal/mid/errors.go
@@ -11,8 +11,9 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// ErrorHandler for catching and responding to errors.
-func ErrorHandler(before web.Handler) web.Handler {
+// Errors handles errors coming out of the call chain. It detects normal
+// application errors which are used to respond to the client in a uniform way.
+func (mw *Middleware) Errors(before web.Handler) web.Handler {
 
 	// Create the handler that will be attached in the middleware chain.
 	h := func(ctx context.Context, log *log.Logger, w http.ResponseWriter, r *http.Request, params map[string]string) error {

--- a/internal/mid/logger.go
+++ b/internal/mid/logger.go
@@ -10,11 +10,9 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// RequestLogger writes some information about the request to the logs in
-// the format: TraceID : (200) GET /foo -> IP ADDR (latency)
-func RequestLogger(before web.Handler) web.Handler {
-
-	// Wrap this handler around the next one provided.
+// Logger writes some information about the request to the logs in the
+// format: TraceID : (200) GET /foo -> IP ADDR (latency)
+func (mw *Middleware) Logger(before web.Handler) web.Handler {
 	h := func(ctx context.Context, log *log.Logger, w http.ResponseWriter, r *http.Request, params map[string]string) error {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.RequestLogger")
 		defer span.End()

--- a/internal/mid/metrics.go
+++ b/internal/mid/metrics.go
@@ -23,7 +23,7 @@ var m = struct {
 }
 
 // Metrics updates program counters.
-func Metrics(before web.Handler) web.Handler {
+func (mw *Middleware) Metrics(before web.Handler) web.Handler {
 
 	// Wrap this handler around the next one provided.
 	h := func(ctx context.Context, log *log.Logger, w http.ResponseWriter, r *http.Request, params map[string]string) error {

--- a/internal/mid/mid.go
+++ b/internal/mid/mid.go
@@ -1,0 +1,11 @@
+package mid
+
+import (
+	"github.com/ardanlabs/service/internal/platform/auth"
+)
+
+// Middleware holds the required state for all web.Middleware functions in this
+// package. Its methods are defined in separate files.
+type Middleware struct {
+	Authenticator *auth.Authenticator
+}


### PR DESCRIPTION
This PR brings the MW changes we made in `service-training` into the main project. It is functionally the same as what we had already reviewed though there are necessarily minor differences because of the other changes in `service-training` that have not yet been merged here.