### PR TITLE
Use ochttp to create initial span

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opencensus.io v0.14.0
 	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b
 	golang.org/x/net v0.0.0-20180724234803-3673e40ba225 // indirect
+	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v8 v8.18.2

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b h1:2b9XGzhjiYsYPnKXoEfL7k
 golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225 h1:kNX+jCowfMYzvlSvJu5pQWEmyWFrBXJ3PBy10xKMXK8=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dimfeld/httptreemux"
+	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"go.opencensus.io/trace"
 )
@@ -36,6 +37,7 @@ type Handler func(ctx context.Context, log *log.Logger, w http.ResponseWriter, r
 // data/logic on this App struct
 type App struct {
 	*httptreemux.TreeMux
+	och      *ochttp.Handler
 	shutdown chan os.Signal
 	log      *log.Logger
 	mw       []Middleware
@@ -43,12 +45,25 @@ type App struct {
 
 // New creates an App value that handle a set of routes for the application.
 func New(shutdown chan os.Signal, log *log.Logger, mw ...Middleware) *App {
-	return &App{
+	app := App{
 		TreeMux:  httptreemux.New(),
 		shutdown: shutdown,
 		log:      log,
 		mw:       mw,
 	}
+
+	// Create an OpenCensus HTTP Handler which wraps the router. This will start
+	// the initial span and annotate it with information about the request/response.
+	//
+	// This is configured to use the W3C TraceContext standard to set the remote
+	// parent if an client request includes the appropriate headers.
+	// https://w3c.github.io/trace-context/
+	app.och = &ochttp.Handler{
+		Handler:     app.TreeMux,
+		Propagation: &tracecontext.HTTPFormat{},
+	}
+
+	return &app
 }
 
 // SignalShutdown is used to gracefully shutdown the app when an integrity
@@ -70,21 +85,7 @@ func (a *App) Handle(verb, path string, handler Handler, mw ...Middleware) {
 
 	// The function to execute for each request.
 	h := func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-
-		// This API is using pointer semantic methods on this empty
-		// struct type :( This is causing the need to declare this
-		// variable here at the top.
-		var hf tracecontext.HTTPFormat
-
-		// Check the request for an existing Trace. The WithSpanContext
-		// function can unmarshal any existing context or create a new one.
-		var ctx context.Context
-		var span *trace.Span
-		if sc, ok := hf.SpanContextFromRequest(r); ok {
-			ctx, span = trace.StartSpanWithRemoteParent(r.Context(), "internal.platform.web", sc)
-		} else {
-			ctx, span = trace.StartSpan(r.Context(), "internal.platform.web")
-		}
+		ctx, span := trace.StartSpan(r.Context(), "internal.platform.web")
 		defer span.End()
 
 		// Set the context with the required values to
@@ -94,11 +95,6 @@ func (a *App) Handle(verb, path string, handler Handler, mw ...Middleware) {
 			Now:     time.Now(),
 		}
 		ctx = context.WithValue(ctx, KeyValues, &v)
-
-		// Set the parent span on the outgoing requests before any other header to
-		// ensure that the trace is ALWAYS added to the request regardless of
-		// any error occuring or not.
-		hf.SpanContextToRequest(span.SpanContext(), r)
 
 		// Call the wrapped handler functions.
 		if err := handler(ctx, a.log, w, r, params); err != nil {
@@ -110,6 +106,13 @@ func (a *App) Handle(verb, path string, handler Handler, mw ...Middleware) {
 
 	// Add this handler for the specified verb and route.
 	a.TreeMux.Handle(verb, path, h)
+}
+
+// ServeHTTP implements the http.Handler interface. It overrides the ServeHTTP
+// of the embedded TreeMux by using the ochttp.Handler instead. That Handler
+// wraps the TreeMux handler so the routes are served.
+func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.och.ServeHTTP(w, r)
 }
 
 // shutdown is a type used to help with the graceful termination of the service.

--- a/vendor/go.opencensus.io/internal/tagencoding/tagencoding.go
+++ b/vendor/go.opencensus.io/internal/tagencoding/tagencoding.go
@@ -1,0 +1,72 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package tagencoding contains the tag encoding
+// used interally by the stats collector.
+package tagencoding // import "go.opencensus.io/internal/tagencoding"
+
+type Values struct {
+	Buffer     []byte
+	WriteIndex int
+	ReadIndex  int
+}
+
+func (vb *Values) growIfRequired(expected int) {
+	if len(vb.Buffer)-vb.WriteIndex < expected {
+		tmp := make([]byte, 2*(len(vb.Buffer)+1)+expected)
+		copy(tmp, vb.Buffer)
+		vb.Buffer = tmp
+	}
+}
+
+func (vb *Values) WriteValue(v []byte) {
+	length := len(v) & 0xff
+	vb.growIfRequired(1 + length)
+
+	// writing length of v
+	vb.Buffer[vb.WriteIndex] = byte(length)
+	vb.WriteIndex++
+
+	if length == 0 {
+		// No value was encoded for this key
+		return
+	}
+
+	// writing v
+	copy(vb.Buffer[vb.WriteIndex:], v[:length])
+	vb.WriteIndex += length
+}
+
+// ReadValue is the helper method to read the values when decoding valuesBytes to a map[Key][]byte.
+func (vb *Values) ReadValue() []byte {
+	// read length of v
+	length := int(vb.Buffer[vb.ReadIndex])
+	vb.ReadIndex++
+	if length == 0 {
+		// No value was encoded for this key
+		return nil
+	}
+
+	// read value of v
+	v := make([]byte, length)
+	endIdx := vb.ReadIndex + length
+	copy(v, vb.Buffer[vb.ReadIndex:endIdx])
+	vb.ReadIndex = endIdx
+	return v
+}
+
+func (vb *Values) Bytes() []byte {
+	return vb.Buffer[:vb.WriteIndex]
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/client.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/client.go
@@ -1,0 +1,97 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// Transport is an http.RoundTripper that instruments all outgoing requests with
+// OpenCensus stats and tracing.
+//
+// The zero value is intended to be a useful default, but for
+// now it's recommended that you explicitly set Propagation, since the default
+// for this may change.
+type Transport struct {
+	// Base may be set to wrap another http.RoundTripper that does the actual
+	// requests. By default http.DefaultTransport is used.
+	//
+	// If base HTTP roundtripper implements CancelRequest,
+	// the returned round tripper will be cancelable.
+	Base http.RoundTripper
+
+	// Propagation defines how traces are propagated. If unspecified, a default
+	// (currently B3 format) will be used.
+	Propagation propagation.HTTPFormat
+
+	// StartOptions are applied to the span started by this Transport around each
+	// request.
+	//
+	// StartOptions.SpanKind will always be set to trace.SpanKindClient
+	// for spans started by this transport.
+	StartOptions trace.StartOptions
+
+	// NameFromRequest holds the function to use for generating the span name
+	// from the information found in the outgoing HTTP Request. By default the
+	// name equals the URL Path.
+	FormatSpanName func(*http.Request) string
+
+	// TODO: Implement tag propagation for HTTP.
+}
+
+// RoundTrip implements http.RoundTripper, delegating to Base and recording stats and traces for the request.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := t.base()
+	// TODO: remove excessive nesting of http.RoundTrippers here.
+	format := t.Propagation
+	if format == nil {
+		format = defaultFormat
+	}
+	spanNameFormatter := t.FormatSpanName
+	if spanNameFormatter == nil {
+		spanNameFormatter = spanNameFromURL
+	}
+	rt = &traceTransport{
+		base:   rt,
+		format: format,
+		startOptions: trace.StartOptions{
+			Sampler:  t.StartOptions.Sampler,
+			SpanKind: trace.SpanKindClient,
+		},
+		formatSpanName: spanNameFormatter,
+	}
+	rt = statsTransport{base: rt}
+	return rt.RoundTrip(req)
+}
+
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/client_stats.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/client_stats.go
@@ -1,0 +1,125 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+// statsTransport is an http.RoundTripper that collects stats for the outgoing requests.
+type statsTransport struct {
+	base http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper, delegating to Base and recording stats for the request.
+func (t statsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, _ := tag.New(req.Context(),
+		tag.Upsert(Host, req.URL.Host),
+		tag.Upsert(Path, req.URL.Path),
+		tag.Upsert(Method, req.Method))
+	req = req.WithContext(ctx)
+	track := &tracker{
+		start: time.Now(),
+		ctx:   ctx,
+	}
+	if req.Body == nil {
+		// TODO: Handle cases where ContentLength is not set.
+		track.reqSize = -1
+	} else if req.ContentLength > 0 {
+		track.reqSize = req.ContentLength
+	}
+	stats.Record(ctx, ClientRequestCount.M(1))
+
+	// Perform request.
+	resp, err := t.base.RoundTrip(req)
+
+	if err != nil {
+		track.statusCode = http.StatusInternalServerError
+		track.end()
+	} else {
+		track.statusCode = resp.StatusCode
+		if resp.Body == nil {
+			track.end()
+		} else {
+			track.body = resp.Body
+			resp.Body = track
+		}
+	}
+	return resp, err
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t statsTransport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base.(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}
+
+type tracker struct {
+	ctx        context.Context
+	respSize   int64
+	reqSize    int64
+	start      time.Time
+	body       io.ReadCloser
+	statusCode int
+	endOnce    sync.Once
+}
+
+var _ io.ReadCloser = (*tracker)(nil)
+
+func (t *tracker) end() {
+	t.endOnce.Do(func() {
+		m := []stats.Measurement{
+			ClientLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
+			ClientResponseBytes.M(t.respSize),
+		}
+		if t.reqSize >= 0 {
+			m = append(m, ClientRequestBytes.M(t.reqSize))
+		}
+		ctx, _ := tag.New(t.ctx, tag.Upsert(StatusCode, strconv.Itoa(t.statusCode)))
+		stats.Record(ctx, m...)
+	})
+}
+
+func (t *tracker) Read(b []byte) (int, error) {
+	n, err := t.body.Read(b)
+	switch err {
+	case nil:
+		t.respSize += int64(n)
+		return n, nil
+	case io.EOF:
+		t.end()
+	}
+	return n, err
+}
+
+func (t *tracker) Close() error {
+	// Invoking endSpan on Close will help catch the cases
+	// in which a read returned a non-nil error, we set the
+	// span status but didn't end the span.
+	t.end()
+	return t.body.Close()
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/doc.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ochttp provides OpenCensus instrumentation for net/http package.
+//
+// For server instrumentation, see Handler. For client-side instrumentation,
+// see Transport.
+package ochttp // import "go.opencensus.io/plugin/ochttp"

--- a/vendor/go.opencensus.io/plugin/ochttp/propagation/b3/b3.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/propagation/b3/b3.go
@@ -1,0 +1,123 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b3 contains a propagation.HTTPFormat implementation
+// for B3 propagation. See https://github.com/openzipkin/b3-propagation
+// for more details.
+package b3 // import "go.opencensus.io/plugin/ochttp/propagation/b3"
+
+import (
+	"encoding/hex"
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// B3 headers that OpenCensus understands.
+const (
+	TraceIDHeader = "X-B3-TraceId"
+	SpanIDHeader  = "X-B3-SpanId"
+	SampledHeader = "X-B3-Sampled"
+)
+
+// HTTPFormat implements propagation.HTTPFormat to propagate
+// traces in HTTP headers in B3 propagation format.
+// HTTPFormat skips the X-B3-ParentId and X-B3-Flags headers
+// because there are additional fields not represented in the
+// OpenCensus span context. Spans created from the incoming
+// header will be the direct children of the client-side span.
+// Similarly, reciever of the outgoing spans should use client-side
+// span created by OpenCensus as the parent.
+type HTTPFormat struct{}
+
+var _ propagation.HTTPFormat = (*HTTPFormat)(nil)
+
+// SpanContextFromRequest extracts a B3 span context from incoming requests.
+func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
+	tid, ok := ParseTraceID(req.Header.Get(TraceIDHeader))
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sid, ok := ParseSpanID(req.Header.Get(SpanIDHeader))
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sampled, _ := ParseSampled(req.Header.Get(SampledHeader))
+	return trace.SpanContext{
+		TraceID:      tid,
+		SpanID:       sid,
+		TraceOptions: sampled,
+	}, true
+}
+
+// ParseTraceID parses the value of the X-B3-TraceId header.
+func ParseTraceID(tid string) (trace.TraceID, bool) {
+	if tid == "" {
+		return trace.TraceID{}, false
+	}
+	b, err := hex.DecodeString(tid)
+	if err != nil {
+		return trace.TraceID{}, false
+	}
+	var traceID trace.TraceID
+	if len(b) <= 8 {
+		// The lower 64-bits.
+		start := 8 + (8 - len(b))
+		copy(traceID[start:], b)
+	} else {
+		start := 16 - len(b)
+		copy(traceID[start:], b)
+	}
+
+	return traceID, true
+}
+
+// ParseSpanID parses the value of the X-B3-SpanId or X-B3-ParentSpanId headers.
+func ParseSpanID(sid string) (spanID trace.SpanID, ok bool) {
+	if sid == "" {
+		return trace.SpanID{}, false
+	}
+	b, err := hex.DecodeString(sid)
+	if err != nil {
+		return trace.SpanID{}, false
+	}
+	start := 8 - len(b)
+	copy(spanID[start:], b)
+	return spanID, true
+}
+
+// ParseSampled parses the value of the X-B3-Sampled header.
+func ParseSampled(sampled string) (trace.TraceOptions, bool) {
+	switch sampled {
+	case "true", "1":
+		return trace.TraceOptions(1), true
+	default:
+		return trace.TraceOptions(0), false
+	}
+}
+
+// SpanContextToRequest modifies the given request to include B3 headers.
+func (f *HTTPFormat) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
+	req.Header.Set(TraceIDHeader, hex.EncodeToString(sc.TraceID[:]))
+	req.Header.Set(SpanIDHeader, hex.EncodeToString(sc.SpanID[:]))
+
+	var sampled string
+	if sc.IsSampled() {
+		sampled = "1"
+	} else {
+		sampled = "0"
+	}
+	req.Header.Set(SampledHeader, sampled)
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/server.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/server.go
@@ -1,0 +1,230 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// Handler is an http.Handler wrapper to instrument your HTTP server with
+// OpenCensus. It supports both stats and tracing.
+//
+// Tracing
+//
+// This handler is aware of the incoming request's span, reading it from request
+// headers as configured using the Propagation field.
+// The extracted span can be accessed from the incoming request's
+// context.
+//
+//    span := trace.FromContext(r.Context())
+//
+// The server span will be automatically ended at the end of ServeHTTP.
+type Handler struct {
+	// Propagation defines how traces are propagated. If unspecified,
+	// B3 propagation will be used.
+	Propagation propagation.HTTPFormat
+
+	// Handler is the handler used to handle the incoming request.
+	Handler http.Handler
+
+	// StartOptions are applied to the span started by this Handler around each
+	// request.
+	//
+	// StartOptions.SpanKind will always be set to trace.SpanKindServer
+	// for spans started by this transport.
+	StartOptions trace.StartOptions
+
+	// IsPublicEndpoint should be set to true for publicly accessible HTTP(S)
+	// servers. If true, any trace metadata set on the incoming request will
+	// be added as a linked trace instead of being added as a parent of the
+	// current trace.
+	IsPublicEndpoint bool
+
+	// FormatSpanName holds the function to use for generating the span name
+	// from the information found in the incoming HTTP Request. By default the
+	// name equals the URL Path.
+	FormatSpanName func(*http.Request) string
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var traceEnd, statsEnd func()
+	r, traceEnd = h.startTrace(w, r)
+	defer traceEnd()
+	w, statsEnd = h.startStats(w, r)
+	defer statsEnd()
+	handler := h.Handler
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	handler.ServeHTTP(w, r)
+}
+
+func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
+	var name string
+	if h.FormatSpanName == nil {
+		name = spanNameFromURL(r)
+	} else {
+		name = h.FormatSpanName(r)
+	}
+	ctx := r.Context()
+	var span *trace.Span
+	sc, ok := h.extractSpanContext(r)
+	if ok && !h.IsPublicEndpoint {
+		ctx, span = trace.StartSpanWithRemoteParent(ctx, name, sc,
+			trace.WithSampler(h.StartOptions.Sampler),
+			trace.WithSpanKind(trace.SpanKindServer))
+	} else {
+		ctx, span = trace.StartSpan(ctx, name,
+			trace.WithSampler(h.StartOptions.Sampler),
+			trace.WithSpanKind(trace.SpanKindServer),
+		)
+		if ok {
+			span.AddLink(trace.Link{
+				TraceID:    sc.TraceID,
+				SpanID:     sc.SpanID,
+				Type:       trace.LinkTypeChild,
+				Attributes: nil,
+			})
+		}
+	}
+	span.AddAttributes(requestAttrs(r)...)
+	return r.WithContext(ctx), span.End
+}
+
+func (h *Handler) extractSpanContext(r *http.Request) (trace.SpanContext, bool) {
+	if h.Propagation == nil {
+		return defaultFormat.SpanContextFromRequest(r)
+	}
+	return h.Propagation.SpanContextFromRequest(r)
+}
+
+func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.ResponseWriter, func()) {
+	ctx, _ := tag.New(r.Context(),
+		tag.Upsert(Host, r.URL.Host),
+		tag.Upsert(Path, r.URL.Path),
+		tag.Upsert(Method, r.Method))
+	track := &trackingResponseWriter{
+		start:  time.Now(),
+		ctx:    ctx,
+		writer: w,
+	}
+	if r.Body == nil {
+		// TODO: Handle cases where ContentLength is not set.
+		track.reqSize = -1
+	} else if r.ContentLength > 0 {
+		track.reqSize = r.ContentLength
+	}
+	stats.Record(ctx, ServerRequestCount.M(1))
+	return track, track.end
+}
+
+type trackingResponseWriter struct {
+	ctx        context.Context
+	reqSize    int64
+	respSize   int64
+	start      time.Time
+	statusCode int
+	statusLine string
+	endOnce    sync.Once
+	writer     http.ResponseWriter
+}
+
+// Compile time assertions for widely used net/http interfaces
+var _ http.CloseNotifier = (*trackingResponseWriter)(nil)
+var _ http.Flusher = (*trackingResponseWriter)(nil)
+var _ http.Hijacker = (*trackingResponseWriter)(nil)
+var _ http.Pusher = (*trackingResponseWriter)(nil)
+var _ http.ResponseWriter = (*trackingResponseWriter)(nil)
+
+var errHijackerUnimplemented = errors.New("ResponseWriter does not implement http.Hijacker")
+
+func (t *trackingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := t.writer.(http.Hijacker)
+	if !ok {
+		return nil, nil, errHijackerUnimplemented
+	}
+	return hj.Hijack()
+}
+
+func (t *trackingResponseWriter) CloseNotify() <-chan bool {
+	cn, ok := t.writer.(http.CloseNotifier)
+	if !ok {
+		return nil
+	}
+	return cn.CloseNotify()
+}
+
+func (t *trackingResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := t.writer.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, opts)
+}
+
+func (t *trackingResponseWriter) end() {
+	t.endOnce.Do(func() {
+		if t.statusCode == 0 {
+			t.statusCode = 200
+		}
+
+		span := trace.FromContext(t.ctx)
+		span.SetStatus(TraceStatus(t.statusCode, t.statusLine))
+
+		m := []stats.Measurement{
+			ServerLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
+			ServerResponseBytes.M(t.respSize),
+		}
+		if t.reqSize >= 0 {
+			m = append(m, ServerRequestBytes.M(t.reqSize))
+		}
+		ctx, _ := tag.New(t.ctx, tag.Upsert(StatusCode, strconv.Itoa(t.statusCode)))
+		stats.Record(ctx, m...)
+	})
+}
+
+func (t *trackingResponseWriter) Header() http.Header {
+	return t.writer.Header()
+}
+
+func (t *trackingResponseWriter) Write(data []byte) (int, error) {
+	n, err := t.writer.Write(data)
+	t.respSize += int64(n)
+	return n, err
+}
+
+func (t *trackingResponseWriter) WriteHeader(statusCode int) {
+	t.writer.WriteHeader(statusCode)
+	t.statusCode = statusCode
+	t.statusLine = http.StatusText(t.statusCode)
+}
+
+func (t *trackingResponseWriter) Flush() {
+	if flusher, ok := t.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/stats.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/stats.go
@@ -1,0 +1,181 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// The following client HTTP measures are supported for use in custom views.
+var (
+	ClientRequestCount  = stats.Int64("opencensus.io/http/client/request_count", "Number of HTTP requests started", stats.UnitDimensionless)
+	ClientRequestBytes  = stats.Int64("opencensus.io/http/client/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	ClientResponseBytes = stats.Int64("opencensus.io/http/client/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
+	ClientLatency       = stats.Float64("opencensus.io/http/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+// The following server HTTP measures are supported for use in custom views:
+var (
+	ServerRequestCount  = stats.Int64("opencensus.io/http/server/request_count", "Number of HTTP requests started", stats.UnitDimensionless)
+	ServerRequestBytes  = stats.Int64("opencensus.io/http/server/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	ServerResponseBytes = stats.Int64("opencensus.io/http/server/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
+	ServerLatency       = stats.Float64("opencensus.io/http/server/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+// The following tags are applied to stats recorded by this package. Host, Path
+// and Method are applied to all measures. StatusCode is not applied to
+// ClientRequestCount or ServerRequestCount, since it is recorded before the status is known.
+var (
+	// Host is the value of the HTTP Host header.
+	//
+	// The value of this tag can be controlled by the HTTP client, so you need
+	// to watch out for potentially generating high-cardinality labels in your
+	// metrics backend if you use this tag in views.
+	Host, _ = tag.NewKey("http.host")
+
+	// StatusCode is the numeric HTTP response status code,
+	// or "error" if a transport error occurred and no status code was read.
+	StatusCode, _ = tag.NewKey("http.status")
+
+	// Path is the URL path (not including query string) in the request.
+	//
+	// The value of this tag can be controlled by the HTTP client, so you need
+	// to watch out for potentially generating high-cardinality labels in your
+	// metrics backend if you use this tag in views.
+	Path, _ = tag.NewKey("http.path")
+
+	// Method is the HTTP method of the request, capitalized (GET, POST, etc.).
+	Method, _ = tag.NewKey("http.method")
+)
+
+// Default distributions used by views in this package.
+var (
+	DefaultSizeDistribution    = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
+	DefaultLatencyDistribution = view.Distribution(0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+)
+
+// Package ochttp provides some convenience views.
+// You need to register the views for data to actually be collected.
+var (
+	ClientRequestCountView = &view.View{
+		Name:        "opencensus.io/http/client/request_count",
+		Description: "Count of HTTP requests started",
+		Measure:     ClientRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ClientRequestBytesView = &view.View{
+		Name:        "opencensus.io/http/client/request_bytes",
+		Description: "Size distribution of HTTP request body",
+		Measure:     ClientRequestBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ClientResponseBytesView = &view.View{
+		Name:        "opencensus.io/http/client/response_bytes",
+		Description: "Size distribution of HTTP response body",
+		Measure:     ClientResponseBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ClientLatencyView = &view.View{
+		Name:        "opencensus.io/http/client/latency",
+		Description: "Latency distribution of HTTP requests",
+		Measure:     ClientLatency,
+		Aggregation: DefaultLatencyDistribution,
+	}
+
+	ClientRequestCountByMethod = &view.View{
+		Name:        "opencensus.io/http/client/request_count_by_method",
+		Description: "Client request count by HTTP method",
+		TagKeys:     []tag.Key{Method},
+		Measure:     ClientRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ClientResponseCountByStatusCode = &view.View{
+		Name:        "opencensus.io/http/client/response_count_by_status_code",
+		Description: "Client response count by status code",
+		TagKeys:     []tag.Key{StatusCode},
+		Measure:     ClientLatency,
+		Aggregation: view.Count(),
+	}
+
+	ServerRequestCountView = &view.View{
+		Name:        "opencensus.io/http/server/request_count",
+		Description: "Count of HTTP requests started",
+		Measure:     ServerRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ServerRequestBytesView = &view.View{
+		Name:        "opencensus.io/http/server/request_bytes",
+		Description: "Size distribution of HTTP request body",
+		Measure:     ServerRequestBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ServerResponseBytesView = &view.View{
+		Name:        "opencensus.io/http/server/response_bytes",
+		Description: "Size distribution of HTTP response body",
+		Measure:     ServerResponseBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ServerLatencyView = &view.View{
+		Name:        "opencensus.io/http/server/latency",
+		Description: "Latency distribution of HTTP requests",
+		Measure:     ServerLatency,
+		Aggregation: DefaultLatencyDistribution,
+	}
+
+	ServerRequestCountByMethod = &view.View{
+		Name:        "opencensus.io/http/server/request_count_by_method",
+		Description: "Server request count by HTTP method",
+		TagKeys:     []tag.Key{Method},
+		Measure:     ServerRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ServerResponseCountByStatusCode = &view.View{
+		Name:        "opencensus.io/http/server/response_count_by_status_code",
+		Description: "Server response count by status code",
+		TagKeys:     []tag.Key{StatusCode},
+		Measure:     ServerLatency,
+		Aggregation: view.Count(),
+	}
+)
+
+// DefaultClientViews are the default client views provided by this package.
+var DefaultClientViews = []*view.View{
+	ClientRequestCountView,
+	ClientRequestBytesView,
+	ClientResponseBytesView,
+	ClientLatencyView,
+	ClientRequestCountByMethod,
+	ClientResponseCountByStatusCode,
+}
+
+// DefaultServerViews are the default server views provided by this package.
+var DefaultServerViews = []*view.View{
+	ServerRequestCountView,
+	ServerRequestBytesView,
+	ServerResponseBytesView,
+	ServerLatencyView,
+	ServerRequestCountByMethod,
+	ServerResponseCountByStatusCode,
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/trace.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/trace.go
@@ -1,0 +1,199 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"io"
+	"net/http"
+
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// TODO(jbd): Add godoc examples.
+
+var defaultFormat propagation.HTTPFormat = &b3.HTTPFormat{}
+
+// Attributes recorded on the span for the requests.
+// Only trace exporters will need them.
+const (
+	HostAttribute       = "http.host"
+	MethodAttribute     = "http.method"
+	PathAttribute       = "http.path"
+	UserAgentAttribute  = "http.user_agent"
+	StatusCodeAttribute = "http.status_code"
+)
+
+type traceTransport struct {
+	base           http.RoundTripper
+	startOptions   trace.StartOptions
+	format         propagation.HTTPFormat
+	formatSpanName func(*http.Request) string
+}
+
+// TODO(jbd): Add message events for request and response size.
+
+// RoundTrip creates a trace.Span and inserts it into the outgoing request's headers.
+// The created span can follow a parent span, if a parent is presented in
+// the request's context.
+func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	name := t.formatSpanName(req)
+	// TODO(jbd): Discuss whether we want to prefix
+	// outgoing requests with Sent.
+	_, span := trace.StartSpan(req.Context(), name,
+		trace.WithSampler(t.startOptions.Sampler),
+		trace.WithSpanKind(trace.SpanKindClient))
+
+	req = req.WithContext(trace.WithSpan(req.Context(), span))
+	if t.format != nil {
+		t.format.SpanContextToRequest(span.SpanContext(), req)
+	}
+
+	span.AddAttributes(requestAttrs(req)...)
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		span.End()
+		return resp, err
+	}
+
+	span.AddAttributes(responseAttrs(resp)...)
+	span.SetStatus(TraceStatus(resp.StatusCode, resp.Status))
+
+	// span.End() will be invoked after
+	// a read from resp.Body returns io.EOF or when
+	// resp.Body.Close() is invoked.
+	resp.Body = &bodyTracker{rc: resp.Body, span: span}
+	return resp, err
+}
+
+// bodyTracker wraps a response.Body and invokes
+// trace.EndSpan on encountering io.EOF on reading
+// the body of the original response.
+type bodyTracker struct {
+	rc   io.ReadCloser
+	span *trace.Span
+}
+
+var _ io.ReadCloser = (*bodyTracker)(nil)
+
+func (bt *bodyTracker) Read(b []byte) (int, error) {
+	n, err := bt.rc.Read(b)
+
+	switch err {
+	case nil:
+		return n, nil
+	case io.EOF:
+		bt.span.End()
+	default:
+		// For all other errors, set the span status
+		bt.span.SetStatus(trace.Status{
+			// Code 2 is the error code for Internal server error.
+			Code:    2,
+			Message: err.Error(),
+		})
+	}
+	return n, err
+}
+
+func (bt *bodyTracker) Close() error {
+	// Invoking endSpan on Close will help catch the cases
+	// in which a read returned a non-nil error, we set the
+	// span status but didn't end the span.
+	bt.span.End()
+	return bt.rc.Close()
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *traceTransport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base.(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}
+
+func spanNameFromURL(req *http.Request) string {
+	return req.URL.Path
+}
+
+func requestAttrs(r *http.Request) []trace.Attribute {
+	return []trace.Attribute{
+		trace.StringAttribute(PathAttribute, r.URL.Path),
+		trace.StringAttribute(HostAttribute, r.URL.Host),
+		trace.StringAttribute(MethodAttribute, r.Method),
+		trace.StringAttribute(UserAgentAttribute, r.UserAgent()),
+	}
+}
+
+func responseAttrs(resp *http.Response) []trace.Attribute {
+	return []trace.Attribute{
+		trace.Int64Attribute(StatusCodeAttribute, int64(resp.StatusCode)),
+	}
+}
+
+// TraceStatus is a utility to convert the HTTP status code to a trace.Status that
+// represents the outcome as closely as possible.
+func TraceStatus(httpStatusCode int, statusLine string) trace.Status {
+	var code int32
+	if httpStatusCode < 200 || httpStatusCode >= 400 {
+		code = trace.StatusCodeUnknown
+	}
+	switch httpStatusCode {
+	case 499:
+		code = trace.StatusCodeCancelled
+	case http.StatusBadRequest:
+		code = trace.StatusCodeInvalidArgument
+	case http.StatusGatewayTimeout:
+		code = trace.StatusCodeDeadlineExceeded
+	case http.StatusNotFound:
+		code = trace.StatusCodeNotFound
+	case http.StatusForbidden:
+		code = trace.StatusCodePermissionDenied
+	case http.StatusUnauthorized: // 401 is actually unauthenticated.
+		code = trace.StatusCodeUnauthenticated
+	case http.StatusTooManyRequests:
+		code = trace.StatusCodeResourceExhausted
+	case http.StatusNotImplemented:
+		code = trace.StatusCodeUnimplemented
+	case http.StatusServiceUnavailable:
+		code = trace.StatusCodeUnavailable
+	case http.StatusOK:
+		code = trace.StatusCodeOK
+	}
+	return trace.Status{Code: code, Message: codeToStr[code]}
+}
+
+var codeToStr = map[int32]string{
+	trace.StatusCodeOK:                 `"OK"`,
+	trace.StatusCodeCancelled:          `"CANCELLED"`,
+	trace.StatusCodeUnknown:            `"UNKNOWN"`,
+	trace.StatusCodeInvalidArgument:    `"INVALID_ARGUMENT"`,
+	trace.StatusCodeDeadlineExceeded:   `"DEADLINE_EXCEEDED"`,
+	trace.StatusCodeNotFound:           `"NOT_FOUND"`,
+	trace.StatusCodeAlreadyExists:      `"ALREADY_EXISTS"`,
+	trace.StatusCodePermissionDenied:   `"PERMISSION_DENIED"`,
+	trace.StatusCodeResourceExhausted:  `"RESOURCE_EXHAUSTED"`,
+	trace.StatusCodeFailedPrecondition: `"FAILED_PRECONDITION"`,
+	trace.StatusCodeAborted:            `"ABORTED"`,
+	trace.StatusCodeOutOfRange:         `"OUT_OF_RANGE"`,
+	trace.StatusCodeUnimplemented:      `"UNIMPLEMENTED"`,
+	trace.StatusCodeInternal:           `"INTERNAL"`,
+	trace.StatusCodeUnavailable:        `"UNAVAILABLE"`,
+	trace.StatusCodeDataLoss:           `"DATA_LOSS"`,
+	trace.StatusCodeUnauthenticated:    `"UNAUTHENTICATED"`,
+}

--- a/vendor/go.opencensus.io/stats/doc.go
+++ b/vendor/go.opencensus.io/stats/doc.go
@@ -1,0 +1,55 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+Package stats contains support for OpenCensus stats recording.
+
+OpenCensus allows users to create typed measures, record measurements,
+aggregate the collected data, and export the aggregated data.
+
+Measures
+
+A measure represents a type of metric to be tracked and recorded.
+For example, latency, request Mb/s, and response Mb/s are measures
+to collect from a server.
+
+Each measure needs to be registered before being used. Measure
+constructors such as Int64 and Float64 automatically
+register the measure by the given name. Each registered measure needs
+to be unique by name. Measures also have a description and a unit.
+
+Libraries can define and export measures for their end users to
+create views and collect instrumentation data.
+
+Recording measurements
+
+Measurement is a data point to be collected for a measure. For example,
+for a latency (ms) measure, 100 is a measurement that represents a 100ms
+latency event. Users collect data points on the existing measures with
+the current context. Tags from the current context are recorded with the
+measurements if they are any.
+
+Recorded measurements are dropped immediately if user is not aggregating
+them via views. Users don't necessarily need to conditionally enable/disable
+recording to reduce cost. Recording of measurements is cheap.
+
+Libraries can always record measurements, and end-users can later decide
+on which measurements they want to collect by registering views. This allows
+libraries to turn on the instrumentation by default.
+*/
+package stats // import "go.opencensus.io/stats"
+
+// TODO(acetechnologist): Add a link to the language independent OpenCensus
+// spec when it is available.

--- a/vendor/go.opencensus.io/stats/internal/record.go
+++ b/vendor/go.opencensus.io/stats/internal/record.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"go.opencensus.io/tag"
+)
+
+// DefaultRecorder will be called for each Record call.
+var DefaultRecorder func(*tag.Map, interface{})
+
+// SubscriptionReporter reports when a view subscribed with a measure.
+var SubscriptionReporter func(measure string)

--- a/vendor/go.opencensus.io/stats/internal/validation.go
+++ b/vendor/go.opencensus.io/stats/internal/validation.go
@@ -1,0 +1,28 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "go.opencensus.io/stats/internal"
+
+const (
+	MaxNameLength = 255
+)
+
+func IsPrintable(str string) bool {
+	for _, r := range str {
+		if !(r >= ' ' && r <= '~') {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/go.opencensus.io/stats/measure.go
+++ b/vendor/go.opencensus.io/stats/measure.go
@@ -1,0 +1,108 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Measure represents a single numeric value to be tracked and recorded.
+// For example, latency, request bytes, and response bytes could be measures
+// to collect from a server.
+//
+// Measures by themselves have no outside effects. In order to be exported,
+// the measure needs to be used in a View. If no Views are defined over a
+// measure, there is very little cost in recording it.
+type Measure interface {
+	// Name returns the name of this measure.
+	//
+	// Measure names are globally unique (among all libraries linked into your program).
+	// We recommend prefixing the measure name with a domain name relevant to your
+	// project or application.
+	//
+	// Measure names are never sent over the wire or exported to backends.
+	// They are only used to create Views.
+	Name() string
+
+	// Description returns the human-readable description of this measure.
+	Description() string
+
+	// Unit returns the units for the values this measure takes on.
+	//
+	// Units are encoded according to the case-sensitive abbreviations from the
+	// Unified Code for Units of Measure: http://unitsofmeasure.org/ucum.html
+	Unit() string
+}
+
+// measureDescriptor is the untyped descriptor associated with each measure.
+// Int64Measure and Float64Measure wrap measureDescriptor to provide typed
+// recording APIs.
+// Two Measures with the same name will have the same measureDescriptor.
+type measureDescriptor struct {
+	subs int32 // access atomically
+
+	name        string
+	description string
+	unit        string
+}
+
+func (m *measureDescriptor) subscribe() {
+	atomic.StoreInt32(&m.subs, 1)
+}
+
+func (m *measureDescriptor) subscribed() bool {
+	return atomic.LoadInt32(&m.subs) == 1
+}
+
+var (
+	mu       sync.RWMutex
+	measures = make(map[string]*measureDescriptor)
+)
+
+func registerMeasureHandle(name, desc, unit string) *measureDescriptor {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if stored, ok := measures[name]; ok {
+		return stored
+	}
+	m := &measureDescriptor{
+		name:        name,
+		description: desc,
+		unit:        unit,
+	}
+	measures[name] = m
+	return m
+}
+
+// Measurement is the numeric value measured when recording stats. Each measure
+// provides methods to create measurements of their kind. For example, Int64Measure
+// provides M to convert an int64 into a measurement.
+type Measurement struct {
+	v float64
+	m Measure
+}
+
+// Value returns the value of the Measurement as a float64.
+func (m Measurement) Value() float64 {
+	return m.v
+}
+
+// Measure returns the Measure from which this Measurement was created.
+func (m Measurement) Measure() Measure {
+	return m.m
+}

--- a/vendor/go.opencensus.io/stats/measure_float64.go
+++ b/vendor/go.opencensus.io/stats/measure_float64.go
@@ -1,0 +1,54 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+// Float64Measure is a measure for float64 values.
+type Float64Measure struct {
+	md *measureDescriptor
+}
+
+// Name returns the name of the measure.
+func (m *Float64Measure) Name() string {
+	return m.md.name
+}
+
+// Description returns the description of the measure.
+func (m *Float64Measure) Description() string {
+	return m.md.description
+}
+
+// Unit returns the unit of the measure.
+func (m *Float64Measure) Unit() string {
+	return m.md.unit
+}
+
+// M creates a new float64 measurement.
+// Use Record to record measurements.
+func (m *Float64Measure) M(v float64) Measurement {
+	if !m.md.subscribed() {
+		return Measurement{}
+	}
+	return Measurement{m: m, v: v}
+}
+
+// Float64 creates a new measure for float64 values.
+//
+// See the documentation for interface Measure for more guidance on the
+// parameters of this function.
+func Float64(name, description, unit string) *Float64Measure {
+	mi := registerMeasureHandle(name, description, unit)
+	return &Float64Measure{mi}
+}

--- a/vendor/go.opencensus.io/stats/measure_int64.go
+++ b/vendor/go.opencensus.io/stats/measure_int64.go
@@ -1,0 +1,54 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+// Int64Measure is a measure for int64 values.
+type Int64Measure struct {
+	md *measureDescriptor
+}
+
+// Name returns the name of the measure.
+func (m *Int64Measure) Name() string {
+	return m.md.name
+}
+
+// Description returns the description of the measure.
+func (m *Int64Measure) Description() string {
+	return m.md.description
+}
+
+// Unit returns the unit of the measure.
+func (m *Int64Measure) Unit() string {
+	return m.md.unit
+}
+
+// M creates a new int64 measurement.
+// Use Record to record measurements.
+func (m *Int64Measure) M(v int64) Measurement {
+	if !m.md.subscribed() {
+		return Measurement{}
+	}
+	return Measurement{m: m, v: float64(v)}
+}
+
+// Int64 creates a new measure for int64 values.
+//
+// See the documentation for interface Measure for more guidance on the
+// parameters of this function.
+func Int64(name, description, unit string) *Int64Measure {
+	mi := registerMeasureHandle(name, description, unit)
+	return &Int64Measure{mi}
+}

--- a/vendor/go.opencensus.io/stats/record.go
+++ b/vendor/go.opencensus.io/stats/record.go
@@ -1,0 +1,52 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+import (
+	"context"
+
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+func init() {
+	internal.SubscriptionReporter = func(measure string) {
+		mu.Lock()
+		measures[measure].subscribe()
+		mu.Unlock()
+	}
+}
+
+// Record records one or multiple measurements with the same tags at once.
+// If there are any tags in the context, measurements will be tagged with them.
+func Record(ctx context.Context, ms ...Measurement) {
+	if len(ms) == 0 {
+		return
+	}
+	var record bool
+	for _, m := range ms {
+		if (m != Measurement{}) {
+			record = true
+			break
+		}
+	}
+	if !record {
+		return
+	}
+	if internal.DefaultRecorder != nil {
+		internal.DefaultRecorder(tag.FromContext(ctx), ms)
+	}
+}

--- a/vendor/go.opencensus.io/stats/units.go
+++ b/vendor/go.opencensus.io/stats/units.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+// Units are encoded according to the case-sensitive abbreviations from the
+// Unified Code for Units of Measure: http://unitsofmeasure.org/ucum.html
+const (
+	UnitNone          = "1" // Deprecated: Use UnitDimensionless.
+	UnitDimensionless = "1"
+	UnitBytes         = "By"
+	UnitMilliseconds  = "ms"
+)

--- a/vendor/go.opencensus.io/stats/view/aggregation.go
+++ b/vendor/go.opencensus.io/stats/view/aggregation.go
@@ -1,0 +1,120 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+// AggType represents the type of aggregation function used on a View.
+type AggType int
+
+// All available aggregation types.
+const (
+	AggTypeNone         AggType = iota // no aggregation; reserved for future use.
+	AggTypeCount                       // the count aggregation, see Count.
+	AggTypeSum                         // the sum aggregation, see Sum.
+	AggTypeDistribution                // the distribution aggregation, see Distribution.
+	AggTypeLastValue                   // the last value aggregation, see LastValue.
+)
+
+func (t AggType) String() string {
+	return aggTypeName[t]
+}
+
+var aggTypeName = map[AggType]string{
+	AggTypeNone:         "None",
+	AggTypeCount:        "Count",
+	AggTypeSum:          "Sum",
+	AggTypeDistribution: "Distribution",
+	AggTypeLastValue:    "LastValue",
+}
+
+// Aggregation represents a data aggregation method. Use one of the functions:
+// Count, Sum, or Distribution to construct an Aggregation.
+type Aggregation struct {
+	Type    AggType   // Type is the AggType of this Aggregation.
+	Buckets []float64 // Buckets are the bucket endpoints if this Aggregation represents a distribution, see Distribution.
+
+	newData func() AggregationData
+}
+
+var (
+	aggCount = &Aggregation{
+		Type: AggTypeCount,
+		newData: func() AggregationData {
+			return &CountData{}
+		},
+	}
+	aggSum = &Aggregation{
+		Type: AggTypeSum,
+		newData: func() AggregationData {
+			return &SumData{}
+		},
+	}
+)
+
+// Count indicates that data collected and aggregated
+// with this method will be turned into a count value.
+// For example, total number of accepted requests can be
+// aggregated by using Count.
+func Count() *Aggregation {
+	return aggCount
+}
+
+// Sum indicates that data collected and aggregated
+// with this method will be summed up.
+// For example, accumulated request bytes can be aggregated by using
+// Sum.
+func Sum() *Aggregation {
+	return aggSum
+}
+
+// Distribution indicates that the desired aggregation is
+// a histogram distribution.
+//
+// An distribution aggregation may contain a histogram of the values in the
+// population. The bucket boundaries for that histogram are described
+// by the bounds. This defines len(bounds)+1 buckets.
+//
+// If len(bounds) >= 2 then the boundaries for bucket index i are:
+//
+//     [-infinity, bounds[i]) for i = 0
+//     [bounds[i-1], bounds[i]) for 0 < i < length
+//     [bounds[i-1], +infinity) for i = length
+//
+// If len(bounds) is 0 then there is no histogram associated with the
+// distribution. There will be a single bucket with boundaries
+// (-infinity, +infinity).
+//
+// If len(bounds) is 1 then there is no finite buckets, and that single
+// element is the common boundary of the overflow and underflow buckets.
+func Distribution(bounds ...float64) *Aggregation {
+	return &Aggregation{
+		Type:    AggTypeDistribution,
+		Buckets: bounds,
+		newData: func() AggregationData {
+			return newDistributionData(bounds)
+		},
+	}
+}
+
+// LastValue only reports the last value recorded using this
+// aggregation. All other measurements will be dropped.
+func LastValue() *Aggregation {
+	return &Aggregation{
+		Type: AggTypeLastValue,
+		newData: func() AggregationData {
+			return &LastValueData{}
+		},
+	}
+}

--- a/vendor/go.opencensus.io/stats/view/aggregation_data.go
+++ b/vendor/go.opencensus.io/stats/view/aggregation_data.go
@@ -1,0 +1,207 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"math"
+)
+
+// AggregationData represents an aggregated value from a collection.
+// They are reported on the view data during exporting.
+// Mosts users won't directly access aggregration data.
+type AggregationData interface {
+	isAggregationData() bool
+	addSample(v float64)
+	clone() AggregationData
+	equal(other AggregationData) bool
+}
+
+const epsilon = 1e-9
+
+// CountData is the aggregated data for the Count aggregation.
+// A count aggregation processes data and counts the recordings.
+//
+// Most users won't directly access count data.
+type CountData struct {
+	Value int64
+}
+
+func (a *CountData) isAggregationData() bool { return true }
+
+func (a *CountData) addSample(v float64) {
+	a.Value = a.Value + 1
+}
+
+func (a *CountData) clone() AggregationData {
+	return &CountData{Value: a.Value}
+}
+
+func (a *CountData) equal(other AggregationData) bool {
+	a2, ok := other.(*CountData)
+	if !ok {
+		return false
+	}
+
+	return a.Value == a2.Value
+}
+
+// SumData is the aggregated data for the Sum aggregation.
+// A sum aggregation processes data and sums up the recordings.
+//
+// Most users won't directly access sum data.
+type SumData struct {
+	Value float64
+}
+
+func (a *SumData) isAggregationData() bool { return true }
+
+func (a *SumData) addSample(f float64) {
+	a.Value += f
+}
+
+func (a *SumData) clone() AggregationData {
+	return &SumData{Value: a.Value}
+}
+
+func (a *SumData) equal(other AggregationData) bool {
+	a2, ok := other.(*SumData)
+	if !ok {
+		return false
+	}
+	return math.Pow(a.Value-a2.Value, 2) < epsilon
+}
+
+// DistributionData is the aggregated data for the
+// Distribution aggregation.
+//
+// Most users won't directly access distribution data.
+type DistributionData struct {
+	Count           int64     // number of data points aggregated
+	Min             float64   // minimum value in the distribution
+	Max             float64   // max value in the distribution
+	Mean            float64   // mean of the distribution
+	SumOfSquaredDev float64   // sum of the squared deviation from the mean
+	CountPerBucket  []int64   // number of occurrences per bucket
+	bounds          []float64 // histogram distribution of the values
+}
+
+func newDistributionData(bounds []float64) *DistributionData {
+	return &DistributionData{
+		CountPerBucket: make([]int64, len(bounds)+1),
+		bounds:         bounds,
+		Min:            math.MaxFloat64,
+		Max:            math.SmallestNonzeroFloat64,
+	}
+}
+
+// Sum returns the sum of all samples collected.
+func (a *DistributionData) Sum() float64 { return a.Mean * float64(a.Count) }
+
+func (a *DistributionData) variance() float64 {
+	if a.Count <= 1 {
+		return 0
+	}
+	return a.SumOfSquaredDev / float64(a.Count-1)
+}
+
+func (a *DistributionData) isAggregationData() bool { return true }
+
+func (a *DistributionData) addSample(f float64) {
+	if f < a.Min {
+		a.Min = f
+	}
+	if f > a.Max {
+		a.Max = f
+	}
+	a.Count++
+	a.incrementBucketCount(f)
+
+	if a.Count == 1 {
+		a.Mean = f
+		return
+	}
+
+	oldMean := a.Mean
+	a.Mean = a.Mean + (f-a.Mean)/float64(a.Count)
+	a.SumOfSquaredDev = a.SumOfSquaredDev + (f-oldMean)*(f-a.Mean)
+}
+
+func (a *DistributionData) incrementBucketCount(f float64) {
+	if len(a.bounds) == 0 {
+		a.CountPerBucket[0]++
+		return
+	}
+
+	for i, b := range a.bounds {
+		if f < b {
+			a.CountPerBucket[i]++
+			return
+		}
+	}
+	a.CountPerBucket[len(a.bounds)]++
+}
+
+func (a *DistributionData) clone() AggregationData {
+	counts := make([]int64, len(a.CountPerBucket))
+	copy(counts, a.CountPerBucket)
+	c := *a
+	c.CountPerBucket = counts
+	return &c
+}
+
+func (a *DistributionData) equal(other AggregationData) bool {
+	a2, ok := other.(*DistributionData)
+	if !ok {
+		return false
+	}
+	if a2 == nil {
+		return false
+	}
+	if len(a.CountPerBucket) != len(a2.CountPerBucket) {
+		return false
+	}
+	for i := range a.CountPerBucket {
+		if a.CountPerBucket[i] != a2.CountPerBucket[i] {
+			return false
+		}
+	}
+	return a.Count == a2.Count && a.Min == a2.Min && a.Max == a2.Max && math.Pow(a.Mean-a2.Mean, 2) < epsilon && math.Pow(a.variance()-a2.variance(), 2) < epsilon
+}
+
+// LastValueData returns the last value recorded for LastValue aggregation.
+type LastValueData struct {
+	Value float64
+}
+
+func (l *LastValueData) isAggregationData() bool {
+	return true
+}
+
+func (l *LastValueData) addSample(v float64) {
+	l.Value = v
+}
+
+func (l *LastValueData) clone() AggregationData {
+	return &LastValueData{l.Value}
+}
+
+func (l *LastValueData) equal(other AggregationData) bool {
+	a2, ok := other.(*LastValueData)
+	if !ok {
+		return false
+	}
+	return l.Value == a2.Value
+}

--- a/vendor/go.opencensus.io/stats/view/collector.go
+++ b/vendor/go.opencensus.io/stats/view/collector.go
@@ -1,0 +1,85 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"sort"
+
+	"go.opencensus.io/internal/tagencoding"
+	"go.opencensus.io/tag"
+)
+
+type collector struct {
+	// signatures holds the aggregations values for each unique tag signature
+	// (values for all keys) to its aggregator.
+	signatures map[string]AggregationData
+	// Aggregation is the description of the aggregation to perform for this
+	// view.
+	a *Aggregation
+}
+
+func (c *collector) addSample(s string, v float64) {
+	aggregator, ok := c.signatures[s]
+	if !ok {
+		aggregator = c.a.newData()
+		c.signatures[s] = aggregator
+	}
+	aggregator.addSample(v)
+}
+
+// collectRows returns a snapshot of the collected Row values.
+func (c *collector) collectedRows(keys []tag.Key) []*Row {
+	rows := make([]*Row, 0, len(c.signatures))
+	for sig, aggregator := range c.signatures {
+		tags := decodeTags([]byte(sig), keys)
+		row := &Row{Tags: tags, Data: aggregator.clone()}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func (c *collector) clearRows() {
+	c.signatures = make(map[string]AggregationData)
+}
+
+// encodeWithKeys encodes the map by using values
+// only associated with the keys provided.
+func encodeWithKeys(m *tag.Map, keys []tag.Key) []byte {
+	vb := &tagencoding.Values{
+		Buffer: make([]byte, len(keys)),
+	}
+	for _, k := range keys {
+		v, _ := m.Value(k)
+		vb.WriteValue([]byte(v))
+	}
+	return vb.Bytes()
+}
+
+// decodeTags decodes tags from the buffer and
+// orders them by the keys.
+func decodeTags(buf []byte, keys []tag.Key) []tag.Tag {
+	vb := &tagencoding.Values{Buffer: buf}
+	var tags []tag.Tag
+	for _, k := range keys {
+		v := vb.ReadValue()
+		if v != nil {
+			tags = append(tags, tag.Tag{Key: k, Value: string(v)})
+		}
+	}
+	vb.ReadIndex = 0
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key.Name() < tags[j].Key.Name() })
+	return tags
+}

--- a/vendor/go.opencensus.io/stats/view/doc.go
+++ b/vendor/go.opencensus.io/stats/view/doc.go
@@ -1,0 +1,46 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+Package view contains support for collecting and exposing aggregates over stats.
+
+In order to collect measurements, views need to be defined and registered.
+A view allows recorded measurements to be filtered and aggregated over a time window.
+
+All recorded measurements can be filtered by a list of tags.
+
+OpenCensus provides several aggregation methods: count, distribution and sum.
+Count aggregation only counts the number of measurement points. Distribution
+aggregation provides statistical summary of the aggregated data. Sum distribution
+sums up the measurement points. Aggregations are cumulative.
+
+Users can dynamically create and delete views.
+
+Libraries can export their own views and claim the view names
+by registering them themselves.
+
+Exporting
+
+Collected and aggregated data can be exported to a metric collection
+backend by registering its exporter.
+
+Multiple exporters can be registered to upload the data to various
+different backends. Users need to unregister the exporters once they
+no longer are needed.
+*/
+package view // import "go.opencensus.io/stats/view"
+
+// TODO(acetechnologist): Add a link to the language independent OpenCensus
+// spec when it is available.

--- a/vendor/go.opencensus.io/stats/view/export.go
+++ b/vendor/go.opencensus.io/stats/view/export.go
@@ -1,0 +1,55 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package view
+
+import "sync"
+
+var (
+	exportersMu sync.RWMutex // guards exporters
+	exporters   = make(map[Exporter]struct{})
+)
+
+// Exporter exports the collected records as view data.
+//
+// The ExportView method should return quickly; if an
+// Exporter takes a significant amount of time to
+// process a Data, that work should be done on another goroutine.
+//
+// The Data should not be modified.
+type Exporter interface {
+	ExportView(viewData *Data)
+}
+
+// RegisterExporter registers an exporter.
+// Collected data will be reported via all the
+// registered exporters. Once you no longer
+// want data to be exported, invoke UnregisterExporter
+// with the previously registered exporter.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
+func RegisterExporter(e Exporter) {
+	exportersMu.Lock()
+	defer exportersMu.Unlock()
+
+	exporters[e] = struct{}{}
+}
+
+// UnregisterExporter unregisters an exporter.
+func UnregisterExporter(e Exporter) {
+	exportersMu.Lock()
+	defer exportersMu.Unlock()
+
+	delete(exporters, e)
+}

--- a/vendor/go.opencensus.io/stats/view/view.go
+++ b/vendor/go.opencensus.io/stats/view/view.go
@@ -1,0 +1,183 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+// View allows users to aggregate the recorded stats.Measurements.
+// Views need to be passed to the Register function to be before data will be
+// collected and sent to Exporters.
+type View struct {
+	Name        string // Name of View. Must be unique. If unset, will default to the name of the Measure.
+	Description string // Description is a human-readable description for this view.
+
+	// TagKeys are the tag keys describing the grouping of this view.
+	// A single Row will be produced for each combination of associated tag values.
+	TagKeys []tag.Key
+
+	// Measure is a stats.Measure to aggregate in this view.
+	Measure stats.Measure
+
+	// Aggregation is the aggregation function tp apply to the set of Measurements.
+	Aggregation *Aggregation
+}
+
+// WithName returns a copy of the View with a new name. This is useful for
+// renaming views to cope with limitations placed on metric names by various
+// backends.
+func (v *View) WithName(name string) *View {
+	vNew := *v
+	vNew.Name = name
+	return &vNew
+}
+
+// same compares two views and returns true if they represent the same aggregation.
+func (v *View) same(other *View) bool {
+	if v == other {
+		return true
+	}
+	if v == nil {
+		return false
+	}
+	return reflect.DeepEqual(v.Aggregation, other.Aggregation) &&
+		v.Measure.Name() == other.Measure.Name()
+}
+
+// canonicalize canonicalizes v by setting explicit
+// defaults for Name and Description and sorting the TagKeys
+func (v *View) canonicalize() error {
+	if v.Measure == nil {
+		return fmt.Errorf("cannot register view %q: measure not set", v.Name)
+	}
+	if v.Aggregation == nil {
+		return fmt.Errorf("cannot register view %q: aggregation not set", v.Name)
+	}
+	if v.Name == "" {
+		v.Name = v.Measure.Name()
+	}
+	if v.Description == "" {
+		v.Description = v.Measure.Description()
+	}
+	if err := checkViewName(v.Name); err != nil {
+		return err
+	}
+	sort.Slice(v.TagKeys, func(i, j int) bool {
+		return v.TagKeys[i].Name() < v.TagKeys[j].Name()
+	})
+	return nil
+}
+
+// viewInternal is the internal representation of a View.
+type viewInternal struct {
+	view       *View  // view is the canonicalized View definition associated with this view.
+	subscribed uint32 // 1 if someone is subscribed and data need to be exported, use atomic to access
+	collector  *collector
+}
+
+func newViewInternal(v *View) (*viewInternal, error) {
+	return &viewInternal{
+		view:      v,
+		collector: &collector{make(map[string]AggregationData), v.Aggregation},
+	}, nil
+}
+
+func (v *viewInternal) subscribe() {
+	atomic.StoreUint32(&v.subscribed, 1)
+}
+
+func (v *viewInternal) unsubscribe() {
+	atomic.StoreUint32(&v.subscribed, 0)
+}
+
+// isSubscribed returns true if the view is exporting
+// data by subscription.
+func (v *viewInternal) isSubscribed() bool {
+	return atomic.LoadUint32(&v.subscribed) == 1
+}
+
+func (v *viewInternal) clearRows() {
+	v.collector.clearRows()
+}
+
+func (v *viewInternal) collectedRows() []*Row {
+	return v.collector.collectedRows(v.view.TagKeys)
+}
+
+func (v *viewInternal) addSample(m *tag.Map, val float64) {
+	if !v.isSubscribed() {
+		return
+	}
+	sig := string(encodeWithKeys(m, v.view.TagKeys))
+	v.collector.addSample(sig, val)
+}
+
+// A Data is a set of rows about usage of the single measure associated
+// with the given view. Each row is specific to a unique set of tags.
+type Data struct {
+	View       *View
+	Start, End time.Time
+	Rows       []*Row
+}
+
+// Row is the collected value for a specific set of key value pairs a.k.a tags.
+type Row struct {
+	Tags []tag.Tag
+	Data AggregationData
+}
+
+func (r *Row) String() string {
+	var buffer bytes.Buffer
+	buffer.WriteString("{ ")
+	buffer.WriteString("{ ")
+	for _, t := range r.Tags {
+		buffer.WriteString(fmt.Sprintf("{%v %v}", t.Key.Name(), t.Value))
+	}
+	buffer.WriteString(" }")
+	buffer.WriteString(fmt.Sprintf("%v", r.Data))
+	buffer.WriteString(" }")
+	return buffer.String()
+}
+
+// Equal returns true if both rows are equal. Tags are expected to be ordered
+// by the key name. Even both rows have the same tags but the tags appear in
+// different orders it will return false.
+func (r *Row) Equal(other *Row) bool {
+	if r == other {
+		return true
+	}
+	return reflect.DeepEqual(r.Tags, other.Tags) && r.Data.equal(other.Data)
+}
+
+func checkViewName(name string) error {
+	if len(name) > internal.MaxNameLength {
+		return fmt.Errorf("view name cannot be larger than %v", internal.MaxNameLength)
+	}
+	if !internal.IsPrintable(name) {
+		return fmt.Errorf("view name needs to be an ASCII string")
+	}
+	return nil
+}

--- a/vendor/go.opencensus.io/stats/view/worker.go
+++ b/vendor/go.opencensus.io/stats/view/worker.go
@@ -1,0 +1,219 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"fmt"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+func init() {
+	defaultWorker = newWorker()
+	go defaultWorker.start()
+	internal.DefaultRecorder = record
+}
+
+type measureRef struct {
+	measure string
+	views   map[*viewInternal]struct{}
+}
+
+type worker struct {
+	measures   map[string]*measureRef
+	views      map[string]*viewInternal
+	startTimes map[*viewInternal]time.Time
+
+	timer      *time.Ticker
+	c          chan command
+	quit, done chan bool
+}
+
+var defaultWorker *worker
+
+var defaultReportingDuration = 10 * time.Second
+
+// Find returns a registered view associated with this name.
+// If no registered view is found, nil is returned.
+func Find(name string) (v *View) {
+	req := &getViewByNameReq{
+		name: name,
+		c:    make(chan *getViewByNameResp),
+	}
+	defaultWorker.c <- req
+	resp := <-req.c
+	return resp.v
+}
+
+// Register begins collecting data for the given views.
+// Once a view is registered, it reports data to the registered exporters.
+func Register(views ...*View) error {
+	for _, v := range views {
+		if err := v.canonicalize(); err != nil {
+			return err
+		}
+	}
+	req := &registerViewReq{
+		views: views,
+		err:   make(chan error),
+	}
+	defaultWorker.c <- req
+	return <-req.err
+}
+
+// Unregister the given views. Data will not longer be exported for these views
+// after Unregister returns.
+// It is not necessary to unregister from views you expect to collect for the
+// duration of your program execution.
+func Unregister(views ...*View) {
+	names := make([]string, len(views))
+	for i := range views {
+		names[i] = views[i].Name
+	}
+	req := &unregisterFromViewReq{
+		views: names,
+		done:  make(chan struct{}),
+	}
+	defaultWorker.c <- req
+	<-req.done
+}
+
+// RetrieveData gets a snapshot of the data collected for the the view registered
+// with the given name. It is intended for testing only.
+func RetrieveData(viewName string) ([]*Row, error) {
+	req := &retrieveDataReq{
+		now: time.Now(),
+		v:   viewName,
+		c:   make(chan *retrieveDataResp),
+	}
+	defaultWorker.c <- req
+	resp := <-req.c
+	return resp.rows, resp.err
+}
+
+func record(tags *tag.Map, ms interface{}) {
+	req := &recordReq{
+		tm: tags,
+		ms: ms.([]stats.Measurement),
+	}
+	defaultWorker.c <- req
+}
+
+// SetReportingPeriod sets the interval between reporting aggregated views in
+// the program. If duration is less than or
+// equal to zero, it enables the default behavior.
+func SetReportingPeriod(d time.Duration) {
+	// TODO(acetechnologist): ensure that the duration d is more than a certain
+	// value. e.g. 1s
+	req := &setReportingPeriodReq{
+		d: d,
+		c: make(chan bool),
+	}
+	defaultWorker.c <- req
+	<-req.c // don't return until the timer is set to the new duration.
+}
+
+func newWorker() *worker {
+	return &worker{
+		measures:   make(map[string]*measureRef),
+		views:      make(map[string]*viewInternal),
+		startTimes: make(map[*viewInternal]time.Time),
+		timer:      time.NewTicker(defaultReportingDuration),
+		c:          make(chan command, 1024),
+		quit:       make(chan bool),
+		done:       make(chan bool),
+	}
+}
+
+func (w *worker) start() {
+	for {
+		select {
+		case cmd := <-w.c:
+			cmd.handleCommand(w)
+		case <-w.timer.C:
+			w.reportUsage(time.Now())
+		case <-w.quit:
+			w.timer.Stop()
+			close(w.c)
+			w.done <- true
+			return
+		}
+	}
+}
+
+func (w *worker) stop() {
+	w.quit <- true
+	<-w.done
+}
+
+func (w *worker) getMeasureRef(name string) *measureRef {
+	if mr, ok := w.measures[name]; ok {
+		return mr
+	}
+	mr := &measureRef{
+		measure: name,
+		views:   make(map[*viewInternal]struct{}),
+	}
+	w.measures[name] = mr
+	return mr
+}
+
+func (w *worker) tryRegisterView(v *View) (*viewInternal, error) {
+	vi, err := newViewInternal(v)
+	if err != nil {
+		return nil, err
+	}
+	if x, ok := w.views[vi.view.Name]; ok {
+		if !x.view.same(vi.view) {
+			return nil, fmt.Errorf("cannot register view %q; a different view with the same name is already registered", v.Name)
+		}
+
+		// the view is already registered so there is nothing to do and the
+		// command is considered successful.
+		return x, nil
+	}
+	w.views[vi.view.Name] = vi
+	ref := w.getMeasureRef(vi.view.Measure.Name())
+	ref.views[vi] = struct{}{}
+	return vi, nil
+}
+
+func (w *worker) reportUsage(now time.Time) {
+	for _, v := range w.views {
+		if !v.isSubscribed() {
+			continue
+		}
+		rows := v.collectedRows()
+		_, ok := w.startTimes[v]
+		if !ok {
+			w.startTimes[v] = now
+		}
+		viewData := &Data{
+			View:  v.view,
+			Start: w.startTimes[v],
+			End:   time.Now(),
+			Rows:  rows,
+		}
+		exportersMu.Lock()
+		for e := range exporters {
+			e.ExportView(viewData)
+		}
+		exportersMu.Unlock()
+	}
+}

--- a/vendor/go.opencensus.io/stats/view/worker_commands.go
+++ b/vendor/go.opencensus.io/stats/view/worker_commands.go
@@ -1,0 +1,171 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+type command interface {
+	handleCommand(w *worker)
+}
+
+// getViewByNameReq is the command to get a view given its name.
+type getViewByNameReq struct {
+	name string
+	c    chan *getViewByNameResp
+}
+
+type getViewByNameResp struct {
+	v *View
+}
+
+func (cmd *getViewByNameReq) handleCommand(w *worker) {
+	v := w.views[cmd.name]
+	if v == nil {
+		cmd.c <- &getViewByNameResp{nil}
+		return
+	}
+	cmd.c <- &getViewByNameResp{v.view}
+}
+
+// registerViewReq is the command to register a view.
+type registerViewReq struct {
+	views []*View
+	err   chan error
+}
+
+func (cmd *registerViewReq) handleCommand(w *worker) {
+	var errstr []string
+	for _, view := range cmd.views {
+		vi, err := w.tryRegisterView(view)
+		if err != nil {
+			errstr = append(errstr, fmt.Sprintf("%s: %v", view.Name, err))
+			continue
+		}
+		internal.SubscriptionReporter(view.Measure.Name())
+		vi.subscribe()
+	}
+	if len(errstr) > 0 {
+		cmd.err <- errors.New(strings.Join(errstr, "\n"))
+	} else {
+		cmd.err <- nil
+	}
+}
+
+// unregisterFromViewReq is the command to unregister to a view. Has no
+// impact on the data collection for client that are pulling data from the
+// library.
+type unregisterFromViewReq struct {
+	views []string
+	done  chan struct{}
+}
+
+func (cmd *unregisterFromViewReq) handleCommand(w *worker) {
+	for _, name := range cmd.views {
+		vi, ok := w.views[name]
+		if !ok {
+			continue
+		}
+
+		vi.unsubscribe()
+		if !vi.isSubscribed() {
+			// this was the last subscription and view is not collecting anymore.
+			// The collected data can be cleared.
+			vi.clearRows()
+		}
+		delete(w.views, name)
+	}
+	cmd.done <- struct{}{}
+}
+
+// retrieveDataReq is the command to retrieve data for a view.
+type retrieveDataReq struct {
+	now time.Time
+	v   string
+	c   chan *retrieveDataResp
+}
+
+type retrieveDataResp struct {
+	rows []*Row
+	err  error
+}
+
+func (cmd *retrieveDataReq) handleCommand(w *worker) {
+	vi, ok := w.views[cmd.v]
+	if !ok {
+		cmd.c <- &retrieveDataResp{
+			nil,
+			fmt.Errorf("cannot retrieve data; view %q is not registered", cmd.v),
+		}
+		return
+	}
+
+	if !vi.isSubscribed() {
+		cmd.c <- &retrieveDataResp{
+			nil,
+			fmt.Errorf("cannot retrieve data; view %q has no subscriptions or collection is not forcibly started", cmd.v),
+		}
+		return
+	}
+	cmd.c <- &retrieveDataResp{
+		vi.collectedRows(),
+		nil,
+	}
+}
+
+// recordReq is the command to record data related to multiple measures
+// at once.
+type recordReq struct {
+	tm *tag.Map
+	ms []stats.Measurement
+}
+
+func (cmd *recordReq) handleCommand(w *worker) {
+	for _, m := range cmd.ms {
+		if (m == stats.Measurement{}) { // not registered
+			continue
+		}
+		ref := w.getMeasureRef(m.Measure().Name())
+		for v := range ref.views {
+			v.addSample(cmd.tm, m.Value())
+		}
+	}
+}
+
+// setReportingPeriodReq is the command to modify the duration between
+// reporting the collected data to the registered clients.
+type setReportingPeriodReq struct {
+	d time.Duration
+	c chan bool
+}
+
+func (cmd *setReportingPeriodReq) handleCommand(w *worker) {
+	w.timer.Stop()
+	if cmd.d <= 0 {
+		w.timer = time.NewTicker(defaultReportingDuration)
+	} else {
+		w.timer = time.NewTicker(cmd.d)
+	}
+	cmd.c <- true
+}

--- a/vendor/go.opencensus.io/tag/context.go
+++ b/vendor/go.opencensus.io/tag/context.go
@@ -1,0 +1,41 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+import "context"
+
+// FromContext returns the tag map stored in the context.
+func FromContext(ctx context.Context) *Map {
+	// The returned tag map shouldn't be mutated.
+	ts := ctx.Value(mapCtxKey)
+	if ts == nil {
+		return nil
+	}
+	return ts.(*Map)
+}
+
+// NewContext creates a new context with the given tag map.
+// To propagate a tag map to downstream methods and downstream RPCs, add a tag map
+// to the current context. NewContext will return a copy of the current context,
+// and put the tag map into the returned one.
+// If there is already a tag map in the current context, it will be replaced with m.
+func NewContext(ctx context.Context, m *Map) context.Context {
+	return context.WithValue(ctx, mapCtxKey, m)
+}
+
+type ctxKey struct{}
+
+var mapCtxKey = ctxKey{}

--- a/vendor/go.opencensus.io/tag/doc.go
+++ b/vendor/go.opencensus.io/tag/doc.go
@@ -1,0 +1,26 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+Package tag contains OpenCensus tags.
+
+Tags are key-value pairs. Tags provide additional cardinality to
+the OpenCensus instrumentation data.
+
+Tags can be propagated on the wire and in the same
+process via context.Context. Encode and Decode should be
+used to represent tags into their binary propagation form.
+*/
+package tag // import "go.opencensus.io/tag"

--- a/vendor/go.opencensus.io/tag/key.go
+++ b/vendor/go.opencensus.io/tag/key.go
@@ -1,0 +1,35 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+// Key represents a tag key.
+type Key struct {
+	name string
+}
+
+// NewKey creates or retrieves a string key identified by name.
+// Calling NewKey consequently with the same name returns the same key.
+func NewKey(name string) (Key, error) {
+	if !checkKeyName(name) {
+		return Key{}, errInvalidKeyName
+	}
+	return Key{name: name}, nil
+}
+
+// Name returns the name of the key.
+func (k Key) Name() string {
+	return k.name
+}

--- a/vendor/go.opencensus.io/tag/map.go
+++ b/vendor/go.opencensus.io/tag/map.go
@@ -1,0 +1,197 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+)
+
+// Tag is a key value pair that can be propagated on wire.
+type Tag struct {
+	Key   Key
+	Value string
+}
+
+// Map is a map of tags. Use New to create a context containing
+// a new Map.
+type Map struct {
+	m map[Key]string
+}
+
+// Value returns the value for the key if a value for the key exists.
+func (m *Map) Value(k Key) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	v, ok := m.m[k]
+	return v, ok
+}
+
+func (m *Map) String() string {
+	if m == nil {
+		return "nil"
+	}
+	keys := make([]Key, 0, len(m.m))
+	for k := range m.m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Name() < keys[j].Name() })
+
+	var buffer bytes.Buffer
+	buffer.WriteString("{ ")
+	for _, k := range keys {
+		buffer.WriteString(fmt.Sprintf("{%v %v}", k.name, m.m[k]))
+	}
+	buffer.WriteString(" }")
+	return buffer.String()
+}
+
+func (m *Map) insert(k Key, v string) {
+	if _, ok := m.m[k]; ok {
+		return
+	}
+	m.m[k] = v
+}
+
+func (m *Map) update(k Key, v string) {
+	if _, ok := m.m[k]; ok {
+		m.m[k] = v
+	}
+}
+
+func (m *Map) upsert(k Key, v string) {
+	m.m[k] = v
+}
+
+func (m *Map) delete(k Key) {
+	delete(m.m, k)
+}
+
+func newMap() *Map {
+	return &Map{m: make(map[Key]string)}
+}
+
+// Mutator modifies a tag map.
+type Mutator interface {
+	Mutate(t *Map) (*Map, error)
+}
+
+// Insert returns a mutator that inserts a
+// value associated with k. If k already exists in the tag map,
+// mutator doesn't update the value.
+func Insert(k Key, v string) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			if !checkValue(v) {
+				return nil, errInvalidValue
+			}
+			m.insert(k, v)
+			return m, nil
+		},
+	}
+}
+
+// Update returns a mutator that updates the
+// value of the tag associated with k with v. If k doesn't
+// exists in the tag map, the mutator doesn't insert the value.
+func Update(k Key, v string) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			if !checkValue(v) {
+				return nil, errInvalidValue
+			}
+			m.update(k, v)
+			return m, nil
+		},
+	}
+}
+
+// Upsert returns a mutator that upserts the
+// value of the tag associated with k with v. It inserts the
+// value if k doesn't exist already. It mutates the value
+// if k already exists.
+func Upsert(k Key, v string) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			if !checkValue(v) {
+				return nil, errInvalidValue
+			}
+			m.upsert(k, v)
+			return m, nil
+		},
+	}
+}
+
+// Delete returns a mutator that deletes
+// the value associated with k.
+func Delete(k Key) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			m.delete(k)
+			return m, nil
+		},
+	}
+}
+
+// New returns a new context that contains a tag map
+// originated from the incoming context and modified
+// with the provided mutators.
+func New(ctx context.Context, mutator ...Mutator) (context.Context, error) {
+	m := newMap()
+	orig := FromContext(ctx)
+	if orig != nil {
+		for k, v := range orig.m {
+			if !checkKeyName(k.Name()) {
+				return ctx, fmt.Errorf("key:%q: %v", k, errInvalidKeyName)
+			}
+			if !checkValue(v) {
+				return ctx, fmt.Errorf("key:%q value:%q: %v", k.Name(), v, errInvalidValue)
+			}
+			m.insert(k, v)
+		}
+	}
+	var err error
+	for _, mod := range mutator {
+		m, err = mod.Mutate(m)
+		if err != nil {
+			return ctx, err
+		}
+	}
+	return NewContext(ctx, m), nil
+}
+
+// Do is similar to pprof.Do: a convenience for installing the tags
+// from the context as Go profiler labels. This allows you to
+// correlated runtime profiling with stats.
+//
+// It converts the key/values from the given map to Go profiler labels
+// and calls pprof.Do.
+//
+// Do is going to do nothing if your Go version is below 1.9.
+func Do(ctx context.Context, f func(ctx context.Context)) {
+	do(ctx, f)
+}
+
+type mutator struct {
+	fn func(t *Map) (*Map, error)
+}
+
+func (m *mutator) Mutate(t *Map) (*Map, error) {
+	return m.fn(t)
+}

--- a/vendor/go.opencensus.io/tag/map_codec.go
+++ b/vendor/go.opencensus.io/tag/map_codec.go
@@ -1,0 +1,234 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// KeyType defines the types of keys allowed. Currently only keyTypeString is
+// supported.
+type keyType byte
+
+const (
+	keyTypeString keyType = iota
+	keyTypeInt64
+	keyTypeTrue
+	keyTypeFalse
+
+	tagsVersionID = byte(0)
+)
+
+type encoderGRPC struct {
+	buf               []byte
+	writeIdx, readIdx int
+}
+
+// writeKeyString writes the fieldID '0' followed by the key string and value
+// string.
+func (eg *encoderGRPC) writeTagString(k, v string) {
+	eg.writeByte(byte(keyTypeString))
+	eg.writeStringWithVarintLen(k)
+	eg.writeStringWithVarintLen(v)
+}
+
+func (eg *encoderGRPC) writeTagUint64(k string, i uint64) {
+	eg.writeByte(byte(keyTypeInt64))
+	eg.writeStringWithVarintLen(k)
+	eg.writeUint64(i)
+}
+
+func (eg *encoderGRPC) writeTagTrue(k string) {
+	eg.writeByte(byte(keyTypeTrue))
+	eg.writeStringWithVarintLen(k)
+}
+
+func (eg *encoderGRPC) writeTagFalse(k string) {
+	eg.writeByte(byte(keyTypeFalse))
+	eg.writeStringWithVarintLen(k)
+}
+
+func (eg *encoderGRPC) writeBytesWithVarintLen(bytes []byte) {
+	length := len(bytes)
+
+	eg.growIfRequired(binary.MaxVarintLen64 + length)
+	eg.writeIdx += binary.PutUvarint(eg.buf[eg.writeIdx:], uint64(length))
+	copy(eg.buf[eg.writeIdx:], bytes)
+	eg.writeIdx += length
+}
+
+func (eg *encoderGRPC) writeStringWithVarintLen(s string) {
+	length := len(s)
+
+	eg.growIfRequired(binary.MaxVarintLen64 + length)
+	eg.writeIdx += binary.PutUvarint(eg.buf[eg.writeIdx:], uint64(length))
+	copy(eg.buf[eg.writeIdx:], s)
+	eg.writeIdx += length
+}
+
+func (eg *encoderGRPC) writeByte(v byte) {
+	eg.growIfRequired(1)
+	eg.buf[eg.writeIdx] = v
+	eg.writeIdx++
+}
+
+func (eg *encoderGRPC) writeUint32(i uint32) {
+	eg.growIfRequired(4)
+	binary.LittleEndian.PutUint32(eg.buf[eg.writeIdx:], i)
+	eg.writeIdx += 4
+}
+
+func (eg *encoderGRPC) writeUint64(i uint64) {
+	eg.growIfRequired(8)
+	binary.LittleEndian.PutUint64(eg.buf[eg.writeIdx:], i)
+	eg.writeIdx += 8
+}
+
+func (eg *encoderGRPC) readByte() byte {
+	b := eg.buf[eg.readIdx]
+	eg.readIdx++
+	return b
+}
+
+func (eg *encoderGRPC) readUint32() uint32 {
+	i := binary.LittleEndian.Uint32(eg.buf[eg.readIdx:])
+	eg.readIdx += 4
+	return i
+}
+
+func (eg *encoderGRPC) readUint64() uint64 {
+	i := binary.LittleEndian.Uint64(eg.buf[eg.readIdx:])
+	eg.readIdx += 8
+	return i
+}
+
+func (eg *encoderGRPC) readBytesWithVarintLen() ([]byte, error) {
+	if eg.readEnded() {
+		return nil, fmt.Errorf("unexpected end while readBytesWithVarintLen '%x' starting at idx '%v'", eg.buf, eg.readIdx)
+	}
+	length, valueStart := binary.Uvarint(eg.buf[eg.readIdx:])
+	if valueStart <= 0 {
+		return nil, fmt.Errorf("unexpected end while readBytesWithVarintLen '%x' starting at idx '%v'", eg.buf, eg.readIdx)
+	}
+
+	valueStart += eg.readIdx
+	valueEnd := valueStart + int(length)
+	if valueEnd > len(eg.buf) {
+		return nil, fmt.Errorf("malformed encoding: length:%v, upper:%v, maxLength:%v", length, valueEnd, len(eg.buf))
+	}
+
+	eg.readIdx = valueEnd
+	return eg.buf[valueStart:valueEnd], nil
+}
+
+func (eg *encoderGRPC) readStringWithVarintLen() (string, error) {
+	bytes, err := eg.readBytesWithVarintLen()
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func (eg *encoderGRPC) growIfRequired(expected int) {
+	if len(eg.buf)-eg.writeIdx < expected {
+		tmp := make([]byte, 2*(len(eg.buf)+1)+expected)
+		copy(tmp, eg.buf)
+		eg.buf = tmp
+	}
+}
+
+func (eg *encoderGRPC) readEnded() bool {
+	return eg.readIdx >= len(eg.buf)
+}
+
+func (eg *encoderGRPC) bytes() []byte {
+	return eg.buf[:eg.writeIdx]
+}
+
+// Encode encodes the tag map into a []byte. It is useful to propagate
+// the tag maps on wire in binary format.
+func Encode(m *Map) []byte {
+	eg := &encoderGRPC{
+		buf: make([]byte, len(m.m)),
+	}
+	eg.writeByte(byte(tagsVersionID))
+	for k, v := range m.m {
+		eg.writeByte(byte(keyTypeString))
+		eg.writeStringWithVarintLen(k.name)
+		eg.writeBytesWithVarintLen([]byte(v))
+	}
+	return eg.bytes()
+}
+
+// Decode decodes the given []byte into a tag map.
+func Decode(bytes []byte) (*Map, error) {
+	ts := newMap()
+	err := DecodeEach(bytes, ts.upsert)
+	if err != nil {
+		// no partial failures
+		return nil, err
+	}
+	return ts, nil
+}
+
+// DecodeEach decodes the given serialized tag map, calling handler for each
+// tag key and value decoded.
+func DecodeEach(bytes []byte, fn func(key Key, val string)) error {
+	eg := &encoderGRPC{
+		buf: bytes,
+	}
+	if len(eg.buf) == 0 {
+		return nil
+	}
+
+	version := eg.readByte()
+	if version > tagsVersionID {
+		return fmt.Errorf("cannot decode: unsupported version: %q; supports only up to: %q", version, tagsVersionID)
+	}
+
+	for !eg.readEnded() {
+		typ := keyType(eg.readByte())
+
+		if typ != keyTypeString {
+			return fmt.Errorf("cannot decode: invalid key type: %q", typ)
+		}
+
+		k, err := eg.readBytesWithVarintLen()
+		if err != nil {
+			return err
+		}
+
+		v, err := eg.readBytesWithVarintLen()
+		if err != nil {
+			return err
+		}
+
+		key, err := NewKey(string(k))
+		if err != nil {
+			return err
+		}
+		val := string(v)
+		if !checkValue(val) {
+			return errInvalidValue
+		}
+		fn(key, val)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/go.opencensus.io/tag/profile_19.go
+++ b/vendor/go.opencensus.io/tag/profile_19.go
@@ -1,0 +1,31 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.9
+
+package tag
+
+import (
+	"context"
+	"runtime/pprof"
+)
+
+func do(ctx context.Context, f func(ctx context.Context)) {
+	m := FromContext(ctx)
+	keyvals := make([]string, 0, 2*len(m.m))
+	for k, v := range m.m {
+		keyvals = append(keyvals, k.Name(), v)
+	}
+	pprof.Do(ctx, pprof.Labels(keyvals...), f)
+}

--- a/vendor/go.opencensus.io/tag/profile_not19.go
+++ b/vendor/go.opencensus.io/tag/profile_not19.go
@@ -1,0 +1,23 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.9
+
+package tag
+
+import "context"
+
+func do(ctx context.Context, f func(ctx context.Context)) {
+	f(ctx)
+}

--- a/vendor/go.opencensus.io/tag/validate.go
+++ b/vendor/go.opencensus.io/tag/validate.go
@@ -1,0 +1,56 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag
+
+import "errors"
+
+const (
+	maxKeyLength = 255
+
+	// valid are restricted to US-ASCII subset (range 0x20 (' ') to 0x7e ('~')).
+	validKeyValueMin = 32
+	validKeyValueMax = 126
+)
+
+var (
+	errInvalidKeyName = errors.New("invalid key name: only ASCII characters accepted; max length must be 255 characters")
+	errInvalidValue   = errors.New("invalid value: only ASCII characters accepted; max length must be 255 characters")
+)
+
+func checkKeyName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	if len(name) > maxKeyLength {
+		return false
+	}
+	return isASCII(name)
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if (c < validKeyValueMin) || (c > validKeyValueMax) {
+			return false
+		}
+	}
+	return true
+}
+
+func checkValue(v string) bool {
+	if len(v) > maxKeyLength {
+		return false
+	}
+	return isASCII(v)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,11 +18,18 @@ github.com/pborman/uuid
 github.com/pkg/errors
 # go.opencensus.io v0.14.0
 go.opencensus.io/trace
+go.opencensus.io/plugin/ochttp
 go.opencensus.io/plugin/ochttp/propagation/tracecontext
 go.opencensus.io/internal
 go.opencensus.io/trace/internal
+go.opencensus.io/plugin/ochttp/propagation/b3
+go.opencensus.io/stats
+go.opencensus.io/stats/view
+go.opencensus.io/tag
 go.opencensus.io/trace/propagation
 go.opencensus.io
+go.opencensus.io/stats/internal
+go.opencensus.io/internal/tagencoding
 # golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish


### PR DESCRIPTION
Using the `ochttp.Handler` as the initial web application handler deals with creating the initial span with or without a remote parent.

It names the initial span after the request URL which is a good idea IMO. This screenshot is an example of a trace for a login attempt

<img width="1435" alt="Screen Shot 2019-04-11 at 2 14 28 PM" src="https://user-images.githubusercontent.com/2027263/55984910-2c3a1600-5c64-11e9-88be-afe28098c8a8.png">

It also captures the status code of the response as well as some other metadata which is annotated on the trace. See second screenshot from the same trace:

<img width="1440" alt="Screen Shot 2019-04-11 at 2 15 28 PM" src="https://user-images.githubusercontent.com/2027263/55984969-4ecc2f00-5c64-11e9-893e-6db027854759.png">