### PR TITLE
Simplify panic handling in middleware

### DIFF
--- a/cmd/sales-api/handlers/routes.go
+++ b/cmd/sales-api/handlers/routes.go
@@ -17,7 +17,8 @@ func API(shutdown chan os.Signal, log *log.Logger, masterDB *db.DB, authenticato
 	// Create the variable that contains all Middleware functions.
 	mw := mid.Middleware{Authenticator: authenticator}
 
-	app := web.New(shutdown, log, mw.Logger, mw.Metrics, mw.Errors)
+	// Construct the web.App which holds all routes as well as common Middleware.
+	app := web.New(shutdown, log, mw.Logger, mw.Errors, mw.Metrics, mw.Panics)
 
 	// Register health check endpoint. This route is not authenticated.
 	check := Check{

--- a/internal/mid/metrics.go
+++ b/internal/mid/metrics.go
@@ -30,13 +30,6 @@ func (mw *Middleware) Metrics(before web.Handler) web.Handler {
 		ctx, span := trace.StartSpan(ctx, "internal.mid.Metrics")
 		defer span.End()
 
-		// If the context is missing this value, request the service
-		// to be shutdown gracefully.
-		v, ok := ctx.Value(web.KeyValues).(*web.Values)
-		if !ok {
-			return web.Shutdown("web value missing from context")
-		}
-
 		err := before(ctx, log, w, r, params)
 
 		// Add one to the request counter.
@@ -49,10 +42,11 @@ func (mw *Middleware) Metrics(before web.Handler) web.Handler {
 
 		// Add one to the errors counter if an error occured
 		// on this reuqest.
-		if v.Error {
+		if err != nil {
 			m.err.Add(1)
 		}
 
+		// Return the error so it can be handled further up the chain.
 		return err
 	}
 

--- a/internal/mid/panics.go
+++ b/internal/mid/panics.go
@@ -1,0 +1,32 @@
+package mid
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/ardanlabs/service/internal/platform/web"
+	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+)
+
+// Panics recovers from panics and converts the panic to an error so it is
+// reported in Metrics and handled in Errors.
+func (mw *Middleware) Panics(next web.Handler) web.Handler {
+	h := func(ctx context.Context, log *log.Logger, w http.ResponseWriter, r *http.Request, params map[string]string) (err error) {
+		ctx, span := trace.StartSpan(ctx, "internal.mid.Panics")
+		defer span.End()
+
+		// Defer a function to recover from a panic and set the err return variable
+		// after the fact. Using the errors package will generate a stack trace.
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.Errorf("panic: %v", r)
+			}
+		}()
+
+		// Call the next Handler and set its return value in the err variable.
+		return next(ctx, log, w, r, params)
+	}
+	return h
+}

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -25,7 +25,6 @@ type Values struct {
 	TraceID    string
 	Now        time.Time
 	StatusCode int
-	Error      bool
 }
 
 // A Handler is a type that handles an http request within our own little mini


### PR DESCRIPTION
This PR removes the `Error bool` field from the `web.Values` struct type. Rather than using this flag variable on each request we can just count errors as they bubble up the middleware chain.

To accomplish this, the "Metrics" middleware is moved so it starts after and finishes before the Error middleware.

Furthermore this PR moves the 19 line panic recovery func from the Error mw into a 7 line deferred func in its own middleware.