### PR TITLE
Extract http client factory into platform/web package and fix typos.

### DIFF
--- a/cmd/sales-api/main.go
+++ b/cmd/sales-api/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ardanlabs/service/internal/platform/db"
 	"github.com/ardanlabs/service/internal/platform/flag"
 	itrace "github.com/ardanlabs/service/internal/platform/trace"
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/trace"
 )

--- a/cmd/sidecar/metrics/main.go
+++ b/cmd/sidecar/metrics/main.go
@@ -79,7 +79,7 @@ func main() {
 	// =========================================================================
 	// Start collectors and publishers
 
-	// Initalize to allow for the collection of metrics.
+	// Initialize to allow for the collection of metrics.
 	collector, err := collector.New(cfg.Collect.From)
 	if err != nil {
 		log.Fatalf("main : Starting collector : %v", err)

--- a/cmd/sidecar/metrics/publisher/datadog/datadog.go
+++ b/cmd/sidecar/metrics/publisher/datadog/datadog.go
@@ -118,7 +118,7 @@ func marshalDatadog(log *log.Logger, data map[string]interface{}) ([]byte, error
 		case int, float64:
 			doc.Series = append(doc.Series, series{
 				Metric: env + "." + key,
-				Points: [][]interface{}{[]interface{}{"$currenttime", value}},
+				Points: [][]interface{}{{"$currenttime", value}},
 				Type:   mType,
 				Host:   host,
 				Tags:   []string{envTag},

--- a/cmd/sidecar/metrics/publisher/expvar/expvar.go
+++ b/cmd/sidecar/metrics/publisher/expvar/expvar.go
@@ -45,7 +45,7 @@ func New(log *log.Logger, host string, route string, readTimeout, writeTimeout t
 	return &exp
 }
 
-// Stop shutsdown the service.
+// Stop shutdown the service.
 func (exp *Expvar) Stop(shutdownTimeout time.Duration) {
 	exp.log.Println("expvar : Start shutdown...")
 	defer exp.log.Println("expvar : Completed")

--- a/cmd/sidecar/metrics/publisher/publisher.go
+++ b/cmd/sidecar/metrics/publisher/publisher.go
@@ -116,7 +116,7 @@ func (s *Stdout) Publish(data map[string]interface{}) {
 		d["heap"] = memStats["Alloc"]
 	}
 
-	// Remove uncessary keys.
+	// Remove unnecessary keys.
 	delete(d, "memstats")
 	delete(d, "cmdline")
 

--- a/internal/mid/metrics.go
+++ b/internal/mid/metrics.go
@@ -40,8 +40,8 @@ func (mw *Middleware) Metrics(before web.Handler) web.Handler {
 			m.gr.Set(int64(runtime.NumGoroutine()))
 		}
 
-		// Add one to the errors counter if an error occured
-		// on this reuqest.
+		// Add one to the errors counter if an error occurred
+		// on this request.
 		if err != nil {
 			m.err.Add(1)
 		}

--- a/internal/platform/auth/authenticator.go
+++ b/internal/platform/auth/authenticator.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 )
 
@@ -25,7 +25,7 @@ type KeyFunc func(keyID string) (*rsa.PublicKey, error)
 func NewSingleKeyFunc(id string, key *rsa.PublicKey) KeyFunc {
 	return func(kid string) (*rsa.PublicKey, error) {
 		if id != kid {
-			return nil, fmt.Errorf("Unrecognized kid %q", kid)
+			return nil, fmt.Errorf("unrecognized kid %q", kid)
 		}
 		return key, nil
 	}

--- a/internal/platform/auth/authenticator_test.go
+++ b/internal/platform/auth/authenticator_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/ardanlabs/service/internal/platform/auth"
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 )
 
 func TestAuthenticator(t *testing.T) {

--- a/internal/platform/auth/claims.go
+++ b/internal/platform/auth/claims.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 )
 

--- a/internal/platform/db/db.go
+++ b/internal/platform/db/db.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 )
 
 // ErrInvalidDBProvided is returned in the event that an uninitialized db is

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-// Container contains the information about the conainer.
+// Container contains the information about the container.
 type Container struct {
 	ID   string
 	Port string

--- a/internal/platform/flag/doc.go
+++ b/internal/platform/flag/doc.go
@@ -29,7 +29,7 @@ As an example, this config struct:
 
 Would produce the following flag output:
 
-	Useage of <app name>
+	Usage of <app name>
 	-a --web_apihost string  <0.0.0.0:3000> : The ip:port for the api endpoint.
 	--web_batchsize int  <1000> : Represents number of items to move.
 	--web_readtimeout Duration  <5s>

--- a/internal/platform/trace/trace_test.go
+++ b/internal/platform/trace/trace_test.go
@@ -21,9 +21,9 @@ const (
 
 // inputSpans represents spans of data for the tests.
 var inputSpans = []*trace.SpanData{
-	&trace.SpanData{Name: "span1"},
-	&trace.SpanData{Name: "span2"},
-	&trace.SpanData{Name: "span3"},
+	{Name: "span1"},
+	{Name: "span2"},
+	{Name: "span3"},
 }
 
 // inputSpansJSON represents a JSON representation of the span data.

--- a/internal/platform/web/request.go
+++ b/internal/platform/web/request.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"strings"
 
-	en "github.com/go-playground/locales/en"
+	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
-	validator "gopkg.in/go-playground/validator.v9"
+	"gopkg.in/go-playground/validator.v9"
 	en_translations "gopkg.in/go-playground/validator.v9/translations/en"
 )
 

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -39,7 +39,7 @@ func Respond(ctx context.Context, log *log.Logger, w http.ResponseWriter, data i
 	w.WriteHeader(code)
 
 	// Send the result back to the client.
-	if _, err := w.Write([]byte(jsonData)); err != nil {
+	if _, err := w.Write(jsonData); err != nil {
 		return err
 	}
 

--- a/internal/product/product.go
+++ b/internal/product/product.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ardanlabs/service/internal/platform/db"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/crypto/bcrypt"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 


### PR DESCRIPTION
Avoid code duplication when creating http client by extracting into a factory method under platform/web package.
Fix DualStack deprecated property.
Fix typos.