### PR TITLE
Remove unused error function

### DIFF
--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -3,15 +3,8 @@ package web
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 )
-
-// RespondErrorMsg wraps a provided error with an HTTP status code. This
-// function should be used when handlers encounter expected errors.
-func RespondErrorMsg(msg string, status int) error {
-	return &Error{errors.New(msg), status, nil}
-}
 
 // RespondError wraps a provided error with an HTTP status code. This
 // function should be used when handlers encounter expected errors.


### PR DESCRIPTION
This function was added in the recent PR but it is never used. I looked around and there are only 2 places in the code base we might use this function.