### PR TITLE
Update conf usage

### DIFF
--- a/cmd/sales-admin/main.go
+++ b/cmd/sales-admin/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	if err := conf.Parse(os.Args[1:], "SALES", &cfg); err != nil {
 		if err == conf.ErrHelpWanted {
-			usage, err := conf.Usage(&cfg)
+			usage, err := conf.Usage("SALES", &cfg)
 			if err != nil {
 				log.Fatalf("main : Parsing Config : %v", err)
 			}

--- a/cmd/sales-api/main.go
+++ b/cmd/sales-api/main.go
@@ -79,7 +79,7 @@ func main() {
 
 	if err := conf.Parse(os.Args[1:], "SALES", &cfg); err != nil {
 		if err == conf.ErrHelpWanted {
-			usage, err := conf.Usage(&cfg)
+			usage, err := conf.Usage("SALES", &cfg)
 			if err != nil {
 				log.Fatalf("main : Parsing Config : %v", err)
 			}

--- a/cmd/sidecar/metrics/main.go
+++ b/cmd/sidecar/metrics/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	if err := conf.Parse(os.Args[1:], "METRICS", &cfg); err != nil {
 		if err == conf.ErrHelpWanted {
-			usage, err := conf.Usage(&cfg)
+			usage, err := conf.Usage("METRICS", &cfg)
 			if err != nil {
 				log.Fatalf("main : Parsing Config : %v", err)
 			}

--- a/cmd/sidecar/tracer/main.go
+++ b/cmd/sidecar/tracer/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	if err := conf.Parse(os.Args[1:], "TRACER", &cfg); err != nil {
 		if err == conf.ErrHelpWanted {
-			usage, err := conf.Usage(&cfg)
+			usage, err := conf.Usage("TRACER", &cfg)
 			if err != nil {
 				log.Fatalf("main : Parsing Config : %v", err)
 			}

--- a/internal/platform/conf/README.md
+++ b/internal/platform/conf/README.md
@@ -44,13 +44,13 @@ Would produce the following usage output:
 Usage: conf.test [options] [arguments]
 
 OPTIONS
-  --a-string/-s/$A_STRING         <string>    (default: B)
-  --an-int/$AN_INT                <int>       (default: 9)
-  --bool/$BOOL                    <bool>
-  --e-dur/-d/$DURATION            <duration>  (default: 1s)
-  --ip-ip/$IP_IP                  <string>    (default: 127.0.0.0)
-  --ip-name/$IP_NAME_VAR          <string>    (default: localhost)
-  --name/$NAME                    <string>    (default: bill)
+  --an-int/$CRUD_AN_INT         <int>       (default: 9)
+  --a-string/-s/$CRUD_A_STRING  <string>    (default: B)
+  --bool/$CRUD_BOOL             <bool>
+  --ip-name/$CRUD_IP_NAME_VAR   <string>    (default: localhost)
+  --ip-ip/$CRUD_IP_IP           <string>    (default: 127.0.0.0)
+  --name/$CRUD_NAME             <string>    (default: bill)
+  --e-dur/-d/$CRUD_DURATION     <duration>  (default: 1s)
   --help/-h
   display this help message
 ```

--- a/internal/platform/conf/conf.go
+++ b/internal/platform/conf/conf.go
@@ -102,13 +102,13 @@ func Parse(args []string, namespace string, cfgStruct interface{}, sources ...So
 }
 
 // Usage provides output to display the config usage on the command line.
-func Usage(v interface{}) (string, error) {
+func Usage(namespace string, v interface{}) (string, error) {
 	fields, err := extractFields(nil, v)
 	if err != nil {
 		return "", err
 	}
 
-	return fmtUsage(fields), nil
+	return fmtUsage(namespace, fields), nil
 }
 
 // String returns a stringified version of the provided conf-tagged

--- a/internal/platform/conf/conf_test.go
+++ b/internal/platform/conf/conf_test.go
@@ -218,7 +218,7 @@ func TestUsage(t *testing.T) {
 				return
 			}
 
-			got, err := conf.Usage(&cfg)
+			got, err := conf.Usage("TEST", &cfg)
 			if err != nil {
 				fmt.Print(err)
 				return
@@ -228,26 +228,21 @@ func TestUsage(t *testing.T) {
 			want := `Usage: conf.test [options] [arguments]
 
 OPTIONS
-  --a-string/-s/$A_STRING         <string>    (default: B)  
-  --an-int/$AN_INT                <int>       (default: 9)  
-  --bool/$BOOL                    <bool>  
-  --e-dur/-d/$DURATION            <duration>  (default: 1s)  
-  --ip-ip/$IP_IP                  <string>    (default: 127.0.0.0)  
-  --ip-name/$IP_NAME_VAR          <string>    (default: localhost)  
-  --name/$NAME                    <string>    (default: bill)  
-  --help/-h
+  --a-string/-s/$TEST_A_STRING  <string>    (default: B)
+  --an-int/$TEST_AN_INT         <int>       (default: 9)
+  --bool/$TEST_BOOL             <bool>      
+  --e-dur/-d/$TEST_DURATION     <duration>  (default: 1s)
+  --ip-ip/$TEST_IP_IP           <string>    (default: 127.0.0.0)
+  --ip-name/$TEST_IP_NAME_VAR   <string>    (default: localhost)
+  --name/$TEST_NAME             <string>    (default: bill)
+  --help/-h                     
   display this help message`
 
-			got = strings.ReplaceAll(got, " ", "")
-			want = strings.ReplaceAll(want, " ", "")
-			bGot := []byte(got)
-			bWant := []byte(want)
-			if diff := cmp.Diff(bGot, bWant); diff != "" {
-				t.Log("got:\n", got)
-				t.Log("\n", bGot)
-				t.Log("want:\n", want)
-				t.Log("\n", bWant)
-				t.Fatalf("\t%s\tShould match byte for byte the output.", failed)
+			gotS := strings.Split(got, "\n")
+			wantS := strings.Split(want, "\n")
+			if diff := cmp.Diff(gotS, wantS); diff != "" {
+				t.Errorf("\t%s\tShould match the output byte for byte. See diff:", failed)
+				t.Log(diff)
 			}
 			t.Logf("\t%s\tShould match byte for byte the output.", success)
 		}

--- a/internal/platform/conf/conf_test.go
+++ b/internal/platform/conf/conf_test.go
@@ -228,13 +228,13 @@ func TestUsage(t *testing.T) {
 			want := `Usage: conf.test [options] [arguments]
 
 OPTIONS
-  --a-string/-s/$TEST_A_STRING  <string>    (default: B)
   --an-int/$TEST_AN_INT         <int>       (default: 9)
+  --a-string/-s/$TEST_A_STRING  <string>    (default: B)
   --bool/$TEST_BOOL             <bool>      
-  --e-dur/-d/$TEST_DURATION     <duration>  (default: 1s)
-  --ip-ip/$TEST_IP_IP           <string>    (default: 127.0.0.0)
   --ip-name/$TEST_IP_NAME_VAR   <string>    (default: localhost)
+  --ip-ip/$TEST_IP_IP           <string>    (default: 127.0.0.0)
   --name/$TEST_NAME             <string>    (default: bill)
+  --e-dur/-d/$TEST_DURATION     <duration>  (default: 1s)
   --help/-h                     
   display this help message`
 

--- a/internal/platform/conf/doc.go
+++ b/internal/platform/conf/doc.go
@@ -45,13 +45,13 @@ Would produce the following usage output:
 Usage: conf.test [options] [arguments]
 
 OPTIONS
-  --a-string/-s/$A_STRING         <string>    (default: B)
-  --an-int/$AN_INT                <int>       (default: 9)
-  --bool/$BOOL                    <bool>
-  --e-dur/-d/$DURATION            <duration>  (default: 1s)
-  --ip-ip/$IP_IP                  <string>    (default: 127.0.0.0)
-  --ip-name/$IP_NAME_VAR          <string>    (default: localhost)
-  --name/$NAME                    <string>    (default: bill)
+  --an-int/$CRUD_AN_INT         <int>       (default: 9)
+  --a-string/-s/$CRUD_A_STRING  <string>    (default: B)
+  --bool/$CRUD_BOOL             <bool>
+  --ip-name/$CRUD_IP_NAME_VAR   <string>    (default: localhost)
+  --ip-ip/$CRUD_IP_IP           <string>    (default: 127.0.0.0)
+  --name/$CRUD_NAME             <string>    (default: bill)
+  --e-dur/-d/$CRUD_DURATION     <duration>  (default: 1s)
   --help/-h
   display this help message
 

--- a/internal/platform/conf/sources.go
+++ b/internal/platform/conf/sources.go
@@ -42,8 +42,8 @@ func (e *env) Source(fld field) (string, bool) {
 }
 
 // envUsage constructs a usage string for the environment variable.
-func envUsage(fld field) string {
-	return "$" + strings.ToUpper(strings.Join(fld.envKey, `_`))
+func envUsage(namespace string, fld field) string {
+	return "$" + strings.ToUpper(namespace) + "_" + strings.ToUpper(strings.Join(fld.envKey, `_`))
 }
 
 // =============================================================================

--- a/internal/platform/conf/usage.go
+++ b/internal/platform/conf/usage.go
@@ -5,18 +5,12 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"sort"
 	"strings"
 	"text/tabwriter"
 )
 
 func fmtUsage(namespace string, fields []field) string {
 	var sb strings.Builder
-
-	// Sort the fields by their name.
-	sort.SliceStable(fields, func(i, j int) bool {
-		return fields[i].name < fields[j].name
-	})
 
 	fields = append(fields, field{
 		name:      "help",

--- a/internal/platform/conf/usage.go
+++ b/internal/platform/conf/usage.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 )
 
-func fmtUsage(fields []field) string {
+func fmtUsage(namespace string, fields []field) string {
 	var sb strings.Builder
 
 	// Sort the fields by their name.
@@ -38,13 +38,13 @@ func fmtUsage(fields []field) string {
 		fmt.Fprintf(w, "  %s", flagUsage(fld))
 
 		if fld.name != "help" {
-			fmt.Fprintf(w, "/%s\t", envUsage(fld))
+			fmt.Fprintf(w, "/%s\t", envUsage(namespace, fld))
 		}
 
 		typeName, help := getTypeAndHelp(&fld)
-		fmt.Fprintf(w, " %s\t%s\t\n", typeName, getOptString(fld))
+		fmt.Fprintf(w, "%s\t%s\n", typeName, getOptString(fld))
 		if help != "" {
-			fmt.Fprintf(w, "      %s\t\t\n", help)
+			fmt.Fprintf(w, "  %s\n", help)
 		}
 	}
 


### PR DESCRIPTION
This PR does two things

1. Include the env var namespace in the usage output
2. Removes sorting of fields. They are instead printed in the order they appear in the config struct which provides a more logical grouping of options and lets the end user control it.

For `sales-admin` and `sales-api` the resulting usage strings look like this:

```
~ $ sales-admin -h
Usage: sales-admin [options] [arguments]

OPTIONS
  --cmd/$SALES_CMD                                      <string>
  --db-user/$SALES_DB_USER                              <string>  (default: postgres)
  --db-password/$SALES_DB_PASSWORD                      <string>  (noprint,default: postgres)
  --db-host/$SALES_DB_HOST                              <string>  (default: localhost)
  --db-name/$SALES_DB_NAME                              <string>  (default: postgres)
  --db-disable-tls/$SALES_DB_DISABLE_TLS                <bool>    (default: false)
  --auth-private-key-file/$SALES_AUTH_PRIVATE_KEY_FILE  <string>  (default: private.pem)
  --user-email/$SALES_USER_EMAIL                        <string>
  --user-password/$SALES_USER_PASSWORD                  <string>
  --help/-h
  display this help message

~ $ sales-api -h
Usage: sales-api [options] [arguments]

OPTIONS
  --web-api-host/$SALES_WEB_API_HOST                    <string>    (default: 0.0.0.0:3000)
  --web-debug-host/$SALES_WEB_DEBUG_HOST                <string>    (default: 0.0.0.0:4000)
  --web-read-timeout/$SALES_WEB_READ_TIMEOUT            <duration>  (default: 5s)
  --web-write-timeout/$SALES_WEB_WRITE_TIMEOUT          <duration>  (default: 5s)
  --web-shutdown-timeout/$SALES_WEB_SHUTDOWN_TIMEOUT    <duration>  (default: 5s)
  --db-user/$SALES_DB_USER                              <string>    (default: postgres)
  --db-password/$SALES_DB_PASSWORD                      <string>    (noprint,default: postgres)
  --db-host/$SALES_DB_HOST                              <string>    (default: localhost)
  --db-name/$SALES_DB_NAME                              <string>    (default: postgres)
  --db-disable-tls/$SALES_DB_DISABLE_TLS                <bool>      (default: false)
  --trace-host/$SALES_TRACE_HOST                        <string>    (default: http://tracer:3002/v1/publish)
  --trace-batch-size/$SALES_TRACE_BATCH_SIZE            <int>       (default: 1000)
  --trace-send-interval/$SALES_TRACE_SEND_INTERVAL      <duration>  (default: 15s)
  --trace-send-timeout/$SALES_TRACE_SEND_TIMEOUT        <duration>  (default: 500ms)
  --auth-key-id/$SALES_AUTH_KEY_ID                      <string>    (default: 1)
  --auth-private-key-file/$SALES_AUTH_PRIVATE_KEY_FILE  <string>    (default: /app/private.pem)
  --auth-algorithm/$SALES_AUTH_ALGORITHM                <string>    (default: RS256)
  --help/-h
  display this help message
```