### PR TITLE
adding the logging of Go's stack trace

### DIFF
--- a/cmd/sales-api/handlers/routes.go
+++ b/cmd/sales-api/handlers/routes.go
@@ -15,7 +15,7 @@ import (
 func API(shutdown chan os.Signal, log *log.Logger, db *sqlx.DB, authenticator *auth.Authenticator) http.Handler {
 
 	// Construct the web.App which holds all routes as well as common Middleware.
-	app := web.NewApp(shutdown, log, mid.Logger(log), mid.Errors(log), mid.Metrics(), mid.Panics())
+	app := web.NewApp(shutdown, log, mid.Logger(log), mid.Errors(log), mid.Metrics(), mid.Panics(log))
 
 	// Register health check endpoint. This route is not authenticated.
 	check := Check{

--- a/cmd/sidecar/tracer/handlers/routes.go
+++ b/cmd/sidecar/tracer/handlers/routes.go
@@ -13,7 +13,7 @@ import (
 // API returns a handler for a set of routes.
 func API(shutdown chan os.Signal, log *log.Logger, zipkinHost string, apiHost string) http.Handler {
 
-	app := web.NewApp(shutdown, log, mid.Logger(log), mid.Errors(log))
+	app := web.NewApp(shutdown, log, mid.Logger(log), mid.Errors(log), mid.Panics(log))
 
 	z := NewZipkin(zipkinHost, apiHost, time.Second)
 	app.Handle("POST", "/v1/publish", z.Publish)

--- a/internal/mid/panics.go
+++ b/internal/mid/panics.go
@@ -2,30 +2,39 @@ package mid
 
 import (
 	"context"
+	"log"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/ardanlabs/service/internal/platform/web"
 	"github.com/pkg/errors"
-	"go.opencensus.io/trace"
 )
 
 // Panics recovers from panics and converts the panic to an error so it is
 // reported in Metrics and handled in Errors.
-func Panics() web.Middleware {
+func Panics(log *log.Logger) web.Middleware {
 
 	// This is the actual middleware function to be executed.
 	f := func(after web.Handler) web.Handler {
 
 		// Wrap this handler around the next one provided.
 		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request, params map[string]string) (err error) {
-			ctx, span := trace.StartSpan(ctx, "internal.mid.Panics")
-			defer span.End()
 
-			// Defer a function to recover from a panic and set the err return variable
-			// after the fact. Using the errors package will generate a stack trace.
+			// If the context is missing this value, request the service
+			// to be shutdown gracefully.
+			v, ok := ctx.Value(web.KeyValues).(*web.Values)
+			if !ok {
+				return web.NewShutdownError("web value missing from context")
+			}
+
+			// Defer a function to recover from a panic and set the err return
+			// variable after the fact.
 			defer func() {
 				if r := recover(); r != nil {
 					err = errors.Errorf("panic: %v", r)
+
+					// Log the Go stack trace for this panic'd goroutine.
+					log.Printf("%s :\n%s", v.TraceID, debug.Stack())
 				}
 			}()
 


### PR DESCRIPTION
We are not logging Go's stack trace for the panic. This is very important.