### PR TITLE
Make server error message more accurate

### DIFF
--- a/cmd/sales-api/main.go
+++ b/cmd/sales-api/main.go
@@ -225,7 +225,7 @@ func run() error {
 	// Blocking main and waiting for shutdown.
 	select {
 	case err := <-serverErrors:
-		return errors.Wrap(err, "starting server")
+		return errors.Wrap(err, "server error")
 
 	case sig := <-shutdown:
 		log.Printf("main : %v : Start shutdown", sig)


### PR DESCRIPTION
When serverError reads off the err channel it is not necessarily just a startup error, so the message should be more generic.