### PR TITLE
Update small typo in dockerfile comment

### DIFF
--- a/dockerfile.sales-api
+++ b/dockerfile.sales-api
@@ -19,7 +19,7 @@ RUN mkdir -p /service
 WORKDIR /service
 COPY . .
 
-# Build the admin tool so we can have it in the container. This should change
+# Build the admin tool so we can have it in the container. This should not change
 # often so do this first.
 WORKDIR /service/cmd/${PACKAGE_PREFIX}sales-admin
 RUN go build -ldflags "-X main.build=${VCS_REF}"


### PR DESCRIPTION
The comment in the Dockerfile says the admin tool changes often, but it is actually the other way around. Added the word 'not'.