### PR TITLE
Removed explicit call to os.Exit(1).

### DIFF
--- a/app/sales-api/main.go
+++ b/app/sales-api/main.go
@@ -43,8 +43,7 @@ func main() {
 	log := log.New(os.Stdout, "SALES : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
 
 	if err := run(log); err != nil {
-		log.Println("main: error:", err)
-		os.Exit(1)
+		log.Fatalln("main: error:", err)
 	}
 }
 


### PR DESCRIPTION
os.Exit(1) is called implicitly by log.Fatalln

Or is there some specific reason for this to be called explicitly, that I am missing?