### PR TITLE
sales-api/tests: fix backwards test names.

### DIFF
--- a/app/sales-api/tests/user_test.go
+++ b/app/sales-api/tests/user_test.go
@@ -157,9 +157,9 @@ func (ut *UserTests) postUser400(t *testing.T) {
 	}
 }
 
-// postUser401 validates a user can't be created unless the calling user is
-// authenticated.
-func (ut *UserTests) postUser401(t *testing.T) {
+// postUser403 validates a user can't be created unless the calling user is
+// an admin. Regular users can't do this.
+func (ut *UserTests) postUser403(t *testing.T) {
 	body, err := json.Marshal(&user.User{})
 	if err != nil {
 		t.Fatal(err)
@@ -184,9 +184,9 @@ func (ut *UserTests) postUser401(t *testing.T) {
 	}
 }
 
-// postUser403 validates a user can't be created unless the calling user is
-// an admin. Regular users can't do this.
-func (ut *UserTests) postUser403(t *testing.T) {
+// postUser401 validates a user can't be created unless the calling user is
+// authenticated.
+func (ut *UserTests) postUser401(t *testing.T) {
 	body, err := json.Marshal(&user.User{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
A small fix on a misnaming of test functions in the sales-api test suite.

postUser403 is supposed to test 403 Forbidden by the service,
but it was actually testing 401 Unauthorized and expecting
a 401 response to pass.

Similarly, postUser401 is supposed to test 401 Unauthorized,
but it was actually testing 403 Forbidden and expecting a
403 response to pass.