### PR TITLE
Replace archived vscode-go link with new version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ https://www.ardanlabs.com/blog/2016/05/installing-go-and-your-workspace.html
 
 **Visual Studio Code**  
 https://code.visualstudio.com/Updates  
-https://github.com/microsoft/vscode-go
+https://github.com/golang/vscode-go
 
 **VIM**  
 http://www.vim.org/download.php  


### PR DESCRIPTION
Researching what a solid extension repo looks like to prepare a comparable emacs starter guide, I noticed [microsoft/vscode-go](https://github.com/microsoft/vscode-go) has been archived.