### PR TITLE
fix sales-admin useradd command - missing name parameter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Leeyong Jing leeyongjing@gmail.com
 Michael Gasch <mgasch@vmware.com>
 Nick Stogner <nstogner@users.noreply.github.com>
 runlevl4 <root@runlevl4.com>
+Si Chan <kinluek@gmail.com>
 Steven Edwards <steven@stephenwithav.com>
 Sundara Senthil <senthil.sundara@gmail.com>
 thethingstheycoded <thethingstheycoded@users.noreply.github.com>

--- a/app/sales-admin/commands/useradd.go
+++ b/app/sales-admin/commands/useradd.go
@@ -13,9 +13,9 @@ import (
 )
 
 // UserAdd adds new users into the database.
-func UserAdd(traceID string, log *log.Logger, cfg database.Config, email, password string) error {
-	if email == "" || password == "" {
-		fmt.Println("help: useradd <email> <password>")
+func UserAdd(traceID string, log *log.Logger, cfg database.Config, name, email, password string) error {
+	if name == "" || email == "" || password == "" {
+		fmt.Println("help: useradd <name> <email> <password>")
 		return ErrHelp
 	}
 
@@ -31,6 +31,7 @@ func UserAdd(traceID string, log *log.Logger, cfg database.Config, email, passwo
 	u := user.New(log, db)
 
 	nu := user.NewUser{
+		Name:            name,
 		Email:           email,
 		Password:        password,
 		PasswordConfirm: password,

--- a/app/sales-admin/main.go
+++ b/app/sales-admin/main.go
@@ -98,9 +98,10 @@ func run(log *log.Logger) error {
 		}
 
 	case "useradd":
-		email := cfg.Args.Num(1)
-		password := cfg.Args.Num(2)
-		if err := commands.UserAdd(traceID, log, dbConfig, email, password); err != nil {
+		name := cfg.Args.Num(1)
+		email := cfg.Args.Num(2)
+		password := cfg.Args.Num(3)
+		if err := commands.UserAdd(traceID, log, dbConfig, name, email, password); err != nil {
 			return errors.Wrap(err, "adding user")
 		}
 


### PR DESCRIPTION
**bug**: useradd command was missing name parameter, causing the validation on user.Create to fail.

I've made the necessary changes to sort this out. 

