### PR TITLE
fix - use shutdown error in authorize when claims are missing

### DIFF
--- a/business/mid/auth.go
+++ b/business/mid/auth.go
@@ -68,7 +68,7 @@ func Authorize(roles ...string) web.Middleware {
 			// If the context is missing this value return failure.
 			claims, ok := ctx.Value(auth.Key).(auth.Claims)
 			if !ok {
-				return errors.New("claims missing from context")
+				return web.NewShutdownError("claims missing from context")
 			}
 
 			if !claims.Authorized(roles...) {


### PR DESCRIPTION
Forgive me if I'm wrong but in the context of your application I think missing claims in the authorize middleware should return a shutdown error as this should only ever be called if we have been successfully authenticated first?