### PR TITLE
fix - add db status check to ensure db is ready for migration

### DIFF
--- a/app/sales-admin/commands/migrate.go
+++ b/app/sales-admin/commands/migrate.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ardanlabs/service/business/data/schema"
 	"github.com/ardanlabs/service/foundation/database"
@@ -18,6 +20,12 @@ func Migrate(cfg database.Config) error {
 		return errors.Wrap(err, "connect database")
 	}
 	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := database.StatusCheck(ctx, db); err != nil {
+		return errors.Wrap(err, "status check database")
+	}
 
 	if err := schema.Migrate(db); err != nil {
 		return errors.Wrap(err, "migrate database")


### PR DESCRIPTION
**bug**: when running `make run` the migration is ran directly after the containers spin up, most of the time this throws an error as the database is not ready to accept requests yet.

`make run` output without db status check:
```bash 
(base) MacBook-Pro:service si.chan$ make run
docker-compose -f zarf/compose/compose.yaml -f zarf/compose/compose-config.yaml up --detach --remove-orphans
Creating network "compose_shared-network" with driver "bridge"
Creating sales_db ... done
Creating zipkin   ... done
Creating sales-api ... done
Creating metrics   ... done
go run app/sales-admin/main.go migrate
ADMIN : 2021/03/21 10:49:11.948744 main.go:74: main: Config :
--svn=develop
--desc=copyright information here
--args=[migrate]
--db-user=postgres
--db-password=xxxxxx
--db-host=0.0.0.0
--db-name=postgres
--db-disable-tls=true
ADMIN : 2021/03/21 10:49:11.952450 main.go:24: error: migrating database: migrate database: EOF
exit status 1
```

**fix**: adding the `database.StatusCheck` with a 10 second timeout ensures there is enough time for the database to get ready for the migration