### PR TITLE
Added middleware for CORS support and the config option needed by it

### DIFF
--- a/app/sales-api/handlers/handlers.go
+++ b/app/sales-api/handlers/handlers.go
@@ -3,6 +3,7 @@
 package handlers
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -16,10 +17,10 @@ import (
 )
 
 // API constructs an http.Handler with all application routes defined.
-func API(build string, shutdown chan os.Signal, log *log.Logger, a *auth.Auth, db *sqlx.DB) http.Handler {
+func API(build string, shutdown chan os.Signal, log *log.Logger, a *auth.Auth, db *sqlx.DB, corsOrigin string) http.Handler {
 
 	// Construct the web.App which holds all routes as well as common Middleware.
-	app := web.NewApp(shutdown, mid.Logger(log), mid.Errors(log), mid.Metrics(), mid.Panics(log))
+	app := web.NewApp(shutdown, mid.Cors(corsOrigin), mid.Logger(log), mid.Errors(log), mid.Metrics(), mid.Panics(log))
 
 	// Register debug check endpoints.
 	cg := checkGroup{
@@ -28,6 +29,11 @@ func API(build string, shutdown chan os.Signal, log *log.Logger, a *auth.Auth, d
 	}
 	app.HandleDebug(http.MethodGet, "/readiness", cg.readiness)
 	app.HandleDebug(http.MethodGet, "/liveness", cg.liveness)
+
+	// Accept CORS 'OPTIONS' preflight requests
+	app.Handle(http.MethodOptions, "/*", func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		return nil
+	})
 
 	// Register user management and authentication endpoints.
 	ug := userGroup{

--- a/app/sales-api/main.go
+++ b/app/sales-api/main.go
@@ -56,6 +56,7 @@ func run(log *log.Logger) error {
 		Web struct {
 			APIHost         string        `conf:"default:0.0.0.0:3000"`
 			DebugHost       string        `conf:"default:0.0.0.0:4000"`
+			CorsOrigin      string        `conf:"default:https://MY_DOMAIN.COM"`
 			ReadTimeout     time.Duration `conf:"default:5s"`
 			WriteTimeout    time.Duration `conf:"default:5s"`
 			ShutdownTimeout time.Duration `conf:"default:5s"`
@@ -213,7 +214,7 @@ func run(log *log.Logger) error {
 
 	api := http.Server{
 		Addr:         cfg.Web.APIHost,
-		Handler:      handlers.API(build, shutdown, log, auth, db),
+		Handler:      handlers.API(build, shutdown, log, auth, db, cfg.Web.CorsOrigin),
 		ReadTimeout:  cfg.Web.ReadTimeout,
 		WriteTimeout: cfg.Web.WriteTimeout,
 	}

--- a/app/sales-api/tests/product_test.go
+++ b/app/sales-api/tests/product_test.go
@@ -42,9 +42,11 @@ func TestProducts(t *testing.T) {
 	)
 	t.Cleanup(test.Teardown)
 
+	corsOrigin := ""
+
 	shutdown := make(chan os.Signal, 1)
 	tests := ProductTests{
-		app:       handlers.API("develop", shutdown, test.Log, test.Auth, test.DB),
+		app:       handlers.API("develop", shutdown, test.Log, test.Auth, test.DB, corsOrigin),
 		userToken: test.Token("admin@example.com", "gophers"),
 	}
 

--- a/app/sales-api/tests/user_test.go
+++ b/app/sales-api/tests/user_test.go
@@ -40,9 +40,11 @@ func TestUsers(t *testing.T) {
 	)
 	t.Cleanup(test.Teardown)
 
+	corsOrigin := ""
+
 	shutdown := make(chan os.Signal, 1)
 	tests := UserTests{
-		app:        handlers.API("develop", shutdown, test.Log, test.Auth, test.DB),
+		app:        handlers.API("develop", shutdown, test.Log, test.Auth, test.DB, corsOrigin),
 		kid:        test.KID,
 		userToken:  test.Token("user@example.com", "gophers"),
 		adminToken: test.Token("admin@example.com", "gophers"),

--- a/business/web/mid/cors.go
+++ b/business/web/mid/cors.go
@@ -1,0 +1,35 @@
+package mid
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ardanlabs/service/foundation/web"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Cors sets the response headers needed for Cross-Origin Resource Sharing
+func Cors(origin string) web.Middleware {
+
+	// This is the actual middleware function to be executed.
+	m := func(handler web.Handler) web.Handler {
+
+		// Create the handler that will be attached in the middleware chain.
+		h := func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			ctx, span := trace.SpanFromContext(ctx).Tracer().Start(ctx, "business.mid.cors")
+			defer span.End()
+
+			// Set CORS Headers
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+
+			// Call the next handler.
+			return handler(ctx, w, r)
+		}
+
+		return h
+	}
+
+	return m
+}


### PR DESCRIPTION
As per [Issue 157](https://github.com/ardanlabs/service/issues/157):
1 - A CORS middleware has been added to the `business/web/mid` layer  
2 - The option for the allowed origin support has been added to the `sales-api` main config
3 - Support for CORS `OPTION` preflight requests was added to the `sales-api` handlers

Regarding the 3rd item on the list, this was a quick hack in my case and I'm not entirely sure this is the most elegant way to do it.
Although I like it being bundled with all the other available routes in the handlers file, I think that ideally this should be hidden "under the hood", maybe around `foundation/web -> handle()`? 
I think a case could be made that this should be part of foundation, as a web service CORS is quite _foundational_, not entirely sure though...
