### PR TITLE
Replaces TrimRight with TrimSuffix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Denis Nefedov <nefedov.d.d@gmail.com>
 dremnik <61884728+dremnik@users.noreply.github.com>
 Dmytro Tananayskiy <dmitriyminer@gmail.com>
 Ed Gonzo <Ed@ardanstudios.com>
+Erik Straub <erik@straub.dev>
 Farrukh Kurbanov <farrukhkurbanov@Administrators-MacBook-Pro.local>
 Haibin Liu <liu.haibin@gmail.com>
 Jacob Walker <jacob@ardanlabs.com>

--- a/foundation/keystore/keystore.go
+++ b/foundation/keystore/keystore.go
@@ -72,7 +72,7 @@ func NewFS(fsys fs.FS) (*KeyStore, error) {
 			return errors.Wrap(err, "parsing auth private key")
 		}
 
-		ks.store[strings.TrimRight(dirEntry.Name(), ".pem")] = privateKey
+		ks.store[strings.TrimSuffix(dirEntry.Name(), ".pem")] = privateKey
 		return nil
 	}
 


### PR DESCRIPTION
`strings.TrimRight("develop.pem", ".pem")` results in "develo" because any of the matching characters on the right are trimmed