### PR TITLE
Use SIGINT from syscall package

### DIFF
--- a/app/sales-api/main.go
+++ b/app/sales-api/main.go
@@ -213,7 +213,7 @@ func run(log *log.Logger) error {
 	// Make a channel to listen for an interrupt or terminate signal from the OS.
 	// Use a buffered channel because the signal package requires it.
 	shutdown := make(chan os.Signal, 1)
-	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
 
 	api := http.Server{
 		Addr:         cfg.Web.APIHost,

--- a/app/sidecar/metrics/main.go
+++ b/app/sidecar/metrics/main.go
@@ -130,7 +130,7 @@ func run(log *log.Logger) error {
 	// Make a channel to listen for an interrupt or terminate signal from the OS.
 	// Use a buffered channel because the signal package requires it.
 	shutdown := make(chan os.Signal, 1)
-	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
 	<-shutdown
 
 	log.Println("main: Start shutdown...")


### PR DESCRIPTION
The `os.Interrupt` variable is really just `syscall.SIGINT`. Using `syscall.SIGINT` is a bit more readable since it matches `syscall.SIGTERM` next to it.

When I first went through the Ultimate Service course I wondered why `os.Interrupt` was being used instead of `syscall.SIGINT`.