### PR TITLE
replacing smart quotes with simple quotes

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ sales:
 		-f zarf/docker/dockerfile.sales-api \
 		-t sales-api-amd64:$(VERSION) \
 		--build-arg VCS_REF=$(VERSION) \
-		--build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		.
 
 metrics:
@@ -44,7 +44,7 @@ metrics:
 		-f zarf/docker/dockerfile.metrics \
 		-t metrics-amd64:$(VERSION) \
 		--build-arg VCS_REF=$(VERSION) \
-		--build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		.
 
 # ==============================================================================


### PR DESCRIPTION
A simple request to replace the default smart quotes with simple quotes as some terminals do not support smart quote characters, and they can cause strange errors in scripts.

macos defaults to smart quotes, this command snippet will disable them globally:

```
defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
```

