### PR TITLE
[Fix] Add back authorization checks for product update & delete. 

### DIFF
--- a/app/services/sales-api/handlers/v1/productgrp/productgrp.go
+++ b/app/services/sales-api/handlers/v1/productgrp/productgrp.go
@@ -60,7 +60,12 @@ func (h Handlers) Update(ctx context.Context, w http.ResponseWriter, r *http.Req
 
 	prd, err := h.Product.QueryByID(ctx, id)
 	if err != nil {
-		return fmt.Errorf("unable to find product[%s]: %w", id, err)
+		switch {
+		case errors.Is(err, product.ErrNotFound):
+			return v1Web.NewRequestError(err, http.StatusNotFound)
+		default:
+			return fmt.Errorf("querying product[%s]: %w", id, err)
+		}
 	}
 	
 	// If you are not an admin and looking to update a product you don't own.
@@ -93,7 +98,12 @@ func (h Handlers) Delete(ctx context.Context, w http.ResponseWriter, r *http.Req
 
 	prd, err := h.Product.QueryByID(ctx, id)
 	if err != nil {
-		return fmt.Errorf("unable to find product[%s]: %w", id, err)
+		switch {
+		case errors.Is(err, product.ErrNotFound):
+			return v1Web.NewRequestError(err, http.StatusNoContent)
+		default:
+			return fmt.Errorf("querying product[%s]: %w", id, err)
+		}
 	}
 
 	// If you are not an admin and looking to delete a product you don't own.

--- a/app/services/sales-api/handlers/v1/productgrp/productgrp.go
+++ b/app/services/sales-api/handlers/v1/productgrp/productgrp.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/ardanlabs/service/business/core/product"
+	"github.com/ardanlabs/service/business/sys/auth"
 	v1Web "github.com/ardanlabs/service/business/web/v1"
 	"github.com/ardanlabs/service/foundation/web"
 )
@@ -45,12 +46,28 @@ func (h Handlers) Update(ctx context.Context, w http.ResponseWriter, r *http.Req
 		return web.NewShutdownError("web value missing from context")
 	}
 
+	claims, err := auth.GetClaims(ctx)
+	if err != nil {
+		return v1Web.NewRequestError(auth.ErrForbidden, http.StatusForbidden)
+	}
+
 	var upd product.UpdateProduct
 	if err := web.Decode(r, &upd); err != nil {
 		return fmt.Errorf("unable to decode payload: %w", err)
 	}
 
 	id := web.Param(r, "id")
+
+	prd, err := h.Product.QueryByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("unable to find product[%s]: %w", id, err)
+	}
+	
+	// If you are not an admin and looking to update a product you don't own.
+	if !claims.Authorized(auth.RoleAdmin) && prd.UserID != claims.Subject {
+		return v1Web.NewRequestError(auth.ErrForbidden, http.StatusForbidden)
+	}
+
 	if err := h.Product.Update(ctx, id, upd, v.Now); err != nil {
 		switch {
 		case errors.Is(err, product.ErrInvalidID):
@@ -67,7 +84,23 @@ func (h Handlers) Update(ctx context.Context, w http.ResponseWriter, r *http.Req
 
 // Delete removes a product from the system.
 func (h Handlers) Delete(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	claims, err := auth.GetClaims(ctx)
+	if err != nil {
+		return v1Web.NewRequestError(auth.ErrForbidden, http.StatusForbidden)
+	}
+
 	id := web.Param(r, "id")
+
+	prd, err := h.Product.QueryByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("unable to find product[%s]: %w", id, err)
+	}
+
+	// If you are not an admin and looking to delete a product you don't own.
+	if !claims.Authorized(auth.RoleAdmin) && prd.UserID != claims.Subject {
+		return v1Web.NewRequestError(auth.ErrForbidden, http.StatusForbidden)
+	}
+
 	if err := h.Product.Delete(ctx, id); err != nil {
 		switch {
 		case errors.Is(err, product.ErrInvalidID):

--- a/business/core/product/product.go
+++ b/business/core/product/product.go
@@ -138,7 +138,7 @@ func (c Core) QueryByID(ctx context.Context, productID string) (Product, error) 
 	return toProduct(dbPrd), nil
 }
 
-// QueryByUserID finds the product identified by a given User ID.
+// QueryByUserID finds the products identified by a given User ID.
 func (c Core) QueryByUserID(ctx context.Context, userID string) ([]Product, error) {
 	if err := validate.CheckID(userID); err != nil {
 		return nil, ErrInvalidID

--- a/business/web/v1/v1.go
+++ b/business/web/v1/v1.go
@@ -1,4 +1,4 @@
-//  Package v1 represents types used by the web application for v1.
+// Package v1 represents types used by the web application for v1.
 package v1
 
 import "errors"


### PR DESCRIPTION
Authorization for product `update` and `delete` actions went missing after the recent `core` updates. 

This fix adds both checks back into the handlers layer.