### PR TITLE
[Fix] Logger prints messages without spaces.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@ Arash Bina <arash@arash.io>
 Askar Sagyndyk <superwhykz@gmail.com>
 Bob Cao <3308031+bobintornado@users.noreply.github.com>
 Burhan Khalid <burhan.khalid@gmail.com>
+Ciprian Cimpan <hello@ciprian.pro>
 Denis Nefedov <nefedov.d.d@gmail.com>
 dremnik <61884728+dremnik@users.noreply.github.com>
 Dmytro Tananayskiy <dmitriyminer@gmail.com>

--- a/business/sys/database/database.go
+++ b/business/sys/database/database.go
@@ -101,7 +101,7 @@ func WithinTran(ctx context.Context, log *zap.SugaredLogger, db Transactor, fn f
 	traceID := web.GetTraceID(ctx)
 
 	// Begin the transaction.
-	log.Info("begin tran", "traceid", traceID)
+	log.Infow("begin tran", "traceid", traceID)
 	tx, err := db.Beginx()
 	if err != nil {
 		return fmt.Errorf("begin tran: %w", err)
@@ -115,7 +115,7 @@ func WithinTran(ctx context.Context, log *zap.SugaredLogger, db Transactor, fn f
 	// need to rollback the transaction.
 	defer func() {
 		if mustRollback {
-			log.Info("rollback tran", "traceid", traceID)
+			log.Infow("rollback tran", "traceid", traceID)
 			if err := tx.Rollback(); err != nil {
 				log.Errorw("unable to rollback tran", "traceid", traceID, "ERROR", err)
 			}
@@ -132,7 +132,7 @@ func WithinTran(ctx context.Context, log *zap.SugaredLogger, db Transactor, fn f
 	mustRollback = false
 
 	// Commit the transaction.
-	log.Info("commit tran", "traceid", traceID)
+	log.Infow("commit tran", "traceid", traceID)
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tran: %w", err)
 	}


### PR DESCRIPTION
Wrong logger method was used for database transactions - as a result, the printed message lacks delimiters.