### PR TITLE
feat: taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,309 @@
+version: '3'
+
+# ==============================================================================
+# Testing running system
+
+# For testing a simple query on the system. Don't forget to `make seed` first.
+# curl --user "admin@example.com:gophers" http://localhost:3000/v1/users/token
+# export TOKEN="COPY TOKEN STRING FROM LAST CALL"
+# curl -H "Authorization: Bearer ${TOKEN}" http://localhost:3000/v1/users/1/2
+
+# For testing load on the service.
+# hey -m GET -c 100 -n 10000 -H "Authorization: Bearer ${TOKEN}" http://localhost:3000/v1/users/1/2
+
+# Access zipkin
+# zipkin: http://localhost:9411
+
+# Access metrics directly (4000) or through the sidecar (3001)
+# expvarmon -ports=":4000" -vars="build,requests,goroutines,errors,panics,mem:memstats.Alloc"
+# expvarmon -ports=":3001" -endpoint="/metrics" -vars="build,requests,goroutines,errors,panics,mem:memstats.Alloc"
+
+# Used to install expvarmon program for metrics dashboard.
+# go install github.com/divan/expvarmon@latest
+
+# To generate a private/public key PEM file.
+# openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+# openssl rsa -pubout -in private.pem -out public.pem
+# ./sales-admin genkey
+
+# ==============================================================================
+# Building containers
+
+# $(shell git rev-parse --short HEAD)
+vars:
+  VERSION: 1.0
+  KIND_CLUSTER: ardan-starter-cluster
+  GCP_PROJECT: ardan-starter-kit
+  GCP_CLUSTER: ardan-starter-cluster
+  GCP_DATABASE: ardan-starter-db
+  GCP_ZONE: us-central1-b
+
+tasks:
+  all:
+    - task: sales
+    - task: metrics
+
+  sales:
+    - docker build
+      -f zarf/docker/dockerfile.sales-api
+      -t sales-api-amd64:{{.VERSION}}
+      --build-arg BUILD_REF={{.VERSION}}
+      --build-arg BUILD_DATE={{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}
+      .
+
+  metrics:
+    - docker build
+      -f zarf/docker/dockerfile.metrics
+      -t metrics-amd64:{{.VERSION}}
+      --build-arg BUILD_REF={{.VERSION}}
+      --build-arg BUILD_DATE={{dateInZone "2006-01-02T15:04:05Z" (now) "UTC"}}
+      .
+
+# ==============================================================================
+# Running from within k8s/kind
+
+# Upgrade to latest Kind (>=v0.11): e.g. brew upgrade kind
+# For full Kind v0.11 release notes: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.0
+# Kind release used for our project: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
+# The image used below was copied by the above link and supports both amd64 and arm64.
+
+  kind-up:
+    - kind create cluster
+      --image kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+      --name {{.KIND_CLUSTER}}
+      --config zarf/k8s/kind/kind-config.yaml
+    - kubectl config set-context --current --namespace=sales-system
+
+  kind-down:
+    - kind delete cluster --name {{.KIND_CLUSTER}}
+
+  kind-load:
+    - cd zarf/k8s/kind/sales-pod; kustomize edit set image sales-api-image=sales-api-amd64:{{.VERSION}}
+    - cd zarf/k8s/kind/sales-pod; kustomize edit set image metrics-image=metrics-amd64:{{.VERSION}}
+    - kind load docker-image sales-api-amd64:{{.VERSION}} --name {{.KIND_CLUSTER}}
+    - kind load docker-image metrics-amd64:{{.VERSION}} --name {{.KIND_CLUSTER}}
+
+  kind-apply:
+    - kustomize build zarf/k8s/kind/database-pod | kubectl apply -f -
+    - kubectl wait --namespace=database-system --timeout=120s --for=condition=Available deployment/database-pod
+    - kustomize build zarf/k8s/kind/zipkin-pod | kubectl apply -f -
+    - kubectl wait --namespace=zipkin-system --timeout=120s --for=condition=Available deployment/zipkin-pod
+    - kustomize build zarf/k8s/kind/sales-pod | kubectl apply -f -
+
+  kind-services-delete:
+    - kustomize build zarf/k8s/kind/sales-pod | kubectl delete -f -
+    - kustomize build zarf/k8s/kind/zipkin-pod | kubectl delete -f -
+    - kustomize build zarf/k8s/kind/database-pod | kubectl delete -f -
+
+  kind-restart:
+    - kubectl rollout restart deployment sales-pod
+
+  kind-update:
+    - task: all
+    - task: kind-load
+    - task: kind-restart
+
+  kind-update-apply:
+    - task: all
+    - task: kind-load
+    - task: kind-apply
+
+  kind-logs:
+    - kubectl logs -l app=sales --all-containers=true -f --tail=100 | go run app/tooling/logfmt/main.go
+
+  kind-logs-sales:
+    - kubectl logs -l app=sales --all-containers=true -f --tail=100 | go run app/tooling/logfmt/main.go -service=SALES-API
+
+  kind-logs-db:
+    - kubectl logs -l app=database --namespace=database-system --all-containers=true -f --tail=100
+
+  kind-logs-zipkin:
+    - kubectl logs -l app=zipkin --namespace=zipkin-system --all-containers=true -f --tail=100
+
+  kind-status:
+    - kubectl get nodes -o wide
+    - kubectl get svc -o wide
+    - kubectl get pods -o wide --watch --all-namespaces
+
+  kind-status-sales:
+    - kubectl get pods -o wide --watch --namespace=sales-system
+
+  kind-status-db:
+    - kubectl get pods -o wide --watch --namespace=database-system
+
+  kind-status-zipkin:
+    - kubectl get pods -o wide --watch --namespace=zipkin-system
+
+  kind-describe:
+    - kubectl describe nodes
+    - kubectl describe svc
+    - kubectl describe pod -l app=sales
+
+  kind-describe-deployment:
+    - kubectl describe deployment sales-pod
+
+  kind-describe-replicaset:
+    - kubectl get rs
+    - kubectl describe rs -l app=sales
+
+  kind-events:
+    - kubectl get ev --sort-by metadata.creationTimestamp
+
+  kind-events-warn:
+    - kubectl get ev --field-selector type=Warning --sort-by metadata.creationTimestamp
+
+  kind-context-sales:
+    - kubectl config set-context --current --namespace=sales-system
+
+  kind-shell:
+    - kubectl exec -it $(shell kubectl get pods | grep app | cut -c1-26) --container app -- /bin/sh
+
+  # kind-database:
+    # - ./admin --db-disable-tls=1 migrate
+    # - ./admin --db-disable-tls=1 seed
+
+# ==============================================================================
+# Administration
+
+  migrate:
+    - go run app/tooling/sales-admin/main.go migrate
+
+  seed:
+    - task: migrate
+    - go run app/tooling/sales-admin/main.go seed
+
+# ==============================================================================
+# Running tests within the local computer
+
+  test:
+    - go test ./... -count=1
+    - staticcheck -checks=all ./...
+
+# ==============================================================================
+# Modules support
+
+  deps-reset:
+    - git checkout -- go.mod
+    - go mod tidy
+    - go mod vendor
+
+  tidy:
+    - go mod tidy
+    - go mod vendor
+
+  deps-upgrade:
+    # go get $(go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -m all)
+    - go get -u -t -d -v ./...
+    - go mod tidy
+    - go mod vendor
+
+  deps-cleancache:
+    - go clean -modcache
+
+  list:
+    - go list -mod=mod all
+
+# ==============================================================================
+# Docker support
+
+  docker-down:
+    cmds:
+      - docker rm -f {{.DOCKER_CONTAINER_LIST}}
+    vars:
+      DOCKER_CONTAINER_LIST:
+        sh: docker ps -aq
+
+  docker-clean:
+    - docker system prune -f	
+
+  docker-kind-logs:
+    - docker logs -f {{.KIND_CLUSTER}}-control-plane
+
+# ==============================================================================
+# GCP
+
+
+  gcp-config:
+    - echo "Setting environment for {{.GCP_PROJECT}}"
+    - gcloud config set project {{.GCP_PROJECT}}
+    - gcloud config set compute/zone {{.GCP_ZONE}}
+    - gcloud auth configure-docker
+
+  gcp-project:
+    - gcloud projects create {{.GCP_PROFJECT}}
+    - gcloud beta billing projects link {{.GCP_PROJECT}} --billing-account={{.ACCOUNT_ID}}
+    - gcloud services enable container.googleapis.com
+
+  gcp-cluster:
+    - gcloud container clusters create {{.GCP_CLUSTER}} --enable-ip-alias --num-nodes=2 --machine-type=n1-standard-2
+    - gcloud compute instances list
+
+  gcp-upload:
+    - docker tag sales-api-amd64:1.0 gcr.io/{{.GCP_PROJECT}}/sales-api-amd64:{{.VERSION}}
+    - docker tag metrics-amd64:1.0 gcr.io/{{.GCP_PROJECT}}/metrics-amd64:{{.VERSION}}
+    - docker push gcr.io/{{.GCP_PROJECT}}/sales-api-amd64:{{.VERSION}}
+    - docker push gcr.io/{{.GCP_PROJECT}}/metrics-amd64:{{.VERSION}}
+
+  gcp-database:
+    # Create User/Password
+    - gcloud beta sql instances create {{.GCP_DATABASE}} --database-version=POSTGRES_9_6 --no-backup --tier=db-f1-micro --zone={{.GCP_ZONE}} --no-assign-ip --network=default
+    - gcloud sql instances describe {{.GCP_DATABASE}}
+
+  gcp-db-assign-ip:
+    - gcloud sql instances patch {{.GCP_DATABASE}} --authorized-networks=[{{.PUBLIC-IP}}/32]
+    - gcloud sql instances describe {{.GCP_DATABASE}}
+
+  gcp-db-private-ip:
+    # IMPORTANT: Make sure you run this command and get the private IP of the DB.
+    - gcloud sql instances describe {{.GCP_DATABASE}}
+
+  gcp-services:
+    - kustomize build zarf/k8s/gcp/sales-pod | kubectl apply -f -
+
+  gcp-status:
+    - gcloud container clusters list
+    - kubectl get nodes -o wide
+    - kubectl get svc -o wide
+    - kubectl get pods -o wide --watch
+
+  gcp-status-full:
+    - kubectl describe nodes
+    - kubectl describe svc
+    - kubectl describe pod -l app=sales
+
+  gcp-events:
+    - kubectl get ev --sort-by metadata.creationTimestamp
+
+  gcp-events-warn:
+    - kubectl get ev --field-selector type=Warning --sort-by metadata.creationTimestamp
+
+  gcp-logs:
+    - kubectl logs -l app=sales --all-containers=true -f --tail=100 | go run app/tooling/logfmt/main.go
+
+  gcp-logs-sales:
+    - kubectl logs -l app=sales --all-containers=true -f --tail=100 | go run app/tooling/logfmt/main.go -service=SALES-API | jq
+
+  gcp-shell:
+    - kubectl exec -it $(shell kubectl get pods | grep sales | cut -c1-26 | head -1) --container app -- /bin/sh
+    # ./admin --db-disable-tls=1 migrate
+    # ./admin --db-disable-tls=1 seed
+
+  gcp-delete-all:
+    - task: gcp-delete
+    - kustomize build zarf/k8s/gcp/sales-pod | kubectl delete -f -
+    - gcloud container clusters delete {{.GCP_CLUSTER}}
+    - gcloud projects delete sales-api
+    - gcloud container images delete gcr.io/{{.GCP_PROJECT}}/sales-api-amd64:{{.VERSION}} --force-delete-tags
+    - gcloud container images delete gcr.io/{{.GCP_PROJECT}}/metrics-amd64:{{.VERSION}} --force-delete-tags
+    - docker image remove gcr.io/sales-api/sales-api-amd64:{{.VERSION}}
+    - docker image remove gcr.io/sales-api/metrics-amd64:{{.VERSION}}
+
+#===============================================================================
+# GKE Installation
+#
+# Install the Google Cloud SDK. This contains the gcloud client needed to perform
+# some operatings
+# https://cloud.google.com/sdk/
+#
+# Installing the K8s kubectl client. 
+# https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -156,7 +156,11 @@ tasks:
     - kubectl config set-context --current --namespace=sales-system
 
   kind-shell:
-    - kubectl exec -it $(shell kubectl get pods | grep app | cut -c1-26) --container app -- /bin/sh
+    cmds:
+      - kubectl exec -it {{range $line := .CONTAINER_PODS | splitLines -}}{{if contains "sales" $line}}{{ $line | splitList " " | first }}{{end}}{{end}} --container app -- /bin/sh
+    vars:
+      CONTAINER_PODS:
+        sh: kubectl get pods
 
   # kind-database:
     # - ./admin --db-disable-tls=1 migrate
@@ -222,7 +226,6 @@ tasks:
 # ==============================================================================
 # GCP
 
-
   gcp-config:
     - echo "Setting environment for {{.GCP_PROJECT}}"
     - gcloud config set project {{.GCP_PROJECT}}
@@ -284,9 +287,13 @@ tasks:
     - kubectl logs -l app=sales --all-containers=true -f --tail=100 | go run app/tooling/logfmt/main.go -service=SALES-API | jq
 
   gcp-shell:
-    - kubectl exec -it $(shell kubectl get pods | grep sales | cut -c1-26 | head -1) --container app -- /bin/sh
-    # ./admin --db-disable-tls=1 migrate
-    # ./admin --db-disable-tls=1 seed
+    cmds:
+      - kubectl exec -it {{range $line := .CONTAINER_PODS | splitLines -}}{{if contains "sales" $line}}{{ $line | splitList " " | first }}{{end}}{{end}} --container app -- /bin/sh
+      # ./admin --db-disable-tls=1 migrate
+      # ./admin --db-disable-tls=1 seed
+    vars:
+      CONTAINER_PODS:
+        sh: kubectl get pods
 
   gcp-delete-all:
     - task: gcp-delete


### PR DESCRIPTION
The current `makefile` is Linux and macOS specific. Although it can be run on Windows using WSL2, this PR adds a [`Taskfile.yml`](https://taskfile.dev/) that has the same commands and can be used across multiple operating systems without relying on shell specific utilities (like `cut`, `grep`, etc.)

It requires the installation of the `task` command, which can be done with `go install github.com/go-task/task/v3/cmd/task@latest`, then all instances of `make` can be replaced with `task`.

```
C:\Users\burhan\service>task tidy
task: [tidy] go mod tidy
go: downloading go.uber.org/zap v1.19.1
...
task: [tidy] go mod vendor
```
Upon merging, the wiki should be updated with instructions for Windows.
