### PR TITLE
runs images as non-root user

### DIFF
--- a/makefile
+++ b/makefile
@@ -143,7 +143,7 @@ kind-context-sales:
 	kubectl config set-context --current --namespace=sales-system
 
 kind-shell:
-	kubectl exec -it $(shell kubectl get pods | grep sales | cut -c1-26) --container app -- /bin/sh
+	kubectl exec -it $(shell kubectl get pods | grep sales | cut -c1-26) --container sales-api -- /bin/sh
 
 kind-database:
 	# ./admin --db-disable-tls=1 migrate

--- a/zarf/docker/dockerfile.metrics
+++ b/zarf/docker/dockerfile.metrics
@@ -27,8 +27,11 @@ RUN go build -ldflags "-X main.build=${BUILD_REF}"
 FROM alpine:3.15
 ARG BUILD_DATE
 ARG BUILD_REF
-COPY --from=build_metrics /service/app/services/metrics/metrics /service/metrics
+RUN addgroup -g 1000 -S metrics && \
+    adduser -u 1000 -h /service -G metrics -S metrics
+COPY --from=build_metrics --chown=metrics:metrics /service/app/services/metrics/metrics /service/metrics
 WORKDIR /service
+USER metrics
 CMD ["./metrics"]
 
 LABEL org.opencontainers.image.created="${BUILD_DATE}" \

--- a/zarf/docker/dockerfile.sales-api
+++ b/zarf/docker/dockerfile.sales-api
@@ -27,10 +27,13 @@ RUN go build -ldflags "-X main.build=${BUILD_REF}"
 FROM alpine:3.15
 ARG BUILD_DATE
 ARG BUILD_REF
-COPY --from=build_sales-api /service/zarf/keys/. /service/zarf/keys/.
-COPY --from=build_sales-api /service/app/tooling/sales-admin/sales-admin /service/sales-admin
-COPY --from=build_sales-api /service/app/services/sales-api/sales-api /service/sales-api
+RUN addgroup -g 1000 -S sales && \
+    adduser -u 1000 -h /service -G sales -S sales
+COPY --from=build_sales-api --chown=sales:sales /service/zarf/keys/. /service/zarf/keys/.
+COPY --from=build_sales-api --chown=sales:sales /service/app/tooling/sales-admin/sales-admin /service/sales-admin
+COPY --from=build_sales-api --chown=sales:sales /service/app/services/sales-api/sales-api /service/sales-api
 WORKDIR /service
+USER sales
 CMD ["./sales-api"]
 
 LABEL org.opencontainers.image.created="${BUILD_DATE}" \


### PR DESCRIPTION
- Following security best practices, both **sales-api** and **metrics** docker images are refactored to run as non-root user.
- Fixed broken `make kind-shell` by changing the container name to the proper one.
