### PR TITLE
[Fix] Added OptionHandler on web.App & updated CORS documentation.

### DIFF
--- a/business/web/v1/mid/cors.go
+++ b/business/web/v1/mid/cors.go
@@ -10,9 +10,9 @@ import (
 /*
 	// This handler needs to be set to be fully compliant with CORS. Do this
 	// in the Routes function.
-	app.OptionsHandler = func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+	app.OptionsHandler(func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 		w.WriteHeader(http.StatusOK)
-	}
+	})
 */
 
 // Cors sets the response headers needed for Cross-Origin Resource Sharing

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -102,3 +102,8 @@ func (a *App) Handle(method string, group string, path string, handler Handler, 
 	}
 	a.mux.Handle(method, finalPath, h)
 }
+
+// OptionsHandler assigns the given HandlerFunc to any OPTIONS request without its own OPTIONS handler.
+func (a *App) OptionsHandler(h httptreemux.HandlerFunc) {
+	a.mux.OptionsHandler = h
+}


### PR DESCRIPTION
`web.App` is missing an `OptionHandler` - this PR adds it and updates the CORS middleware docs.
