### PR TITLE
using pointer semantic on value slice range

### DIFF
--- a/business/core/product/models.go
+++ b/business/core/product/models.go
@@ -49,8 +49,8 @@ func toProduct(dbPrd db.Product) Product {
 
 func toProductSlice(dbPrds []db.Product) []Product {
 	prds := make([]Product, len(dbPrds))
-	for i, dbPrd := range dbPrds {
-		prds[i] = toProduct(dbPrd)
+	for i := range dbPrds {
+		prds[i] = toProduct(dbPrds[i])
 	}
 	return prds
 }

--- a/business/core/user/models.go
+++ b/business/core/user/models.go
@@ -50,8 +50,8 @@ func toUser(dbUsr db.User) User {
 
 func toUserSlice(dbUsrs []db.User) []User {
 	users := make([]User, len(dbUsrs))
-	for i, dbUsr := range dbUsrs {
-		users[i] = toUser(dbUsr)
+	for i := range dbUsrs {
+		users[i] = toUser(dbUsrs[i])
 	}
 	return users
 }


### PR DESCRIPTION
The DB product slice uses value semantics. While ranging on it to convert to the core product, we can use pointer semantic instead of value semantic to prevent an extra copy on the range.
I know it's not too much optimization. 😅