### PR TITLE
omit duplicate copy in metrics docker file

### DIFF
--- a/zarf/docker/dockerfile.metrics
+++ b/zarf/docker/dockerfile.metrics
@@ -14,9 +14,6 @@ ARG BUILD_REF
 # Copy the source code into the container.
 COPY . /service
 
-# Copy the source code into the container.
-COPY . /service
-
 # Build the service binary. We are doing this last since this will be different
 # every time we run through this process.
 WORKDIR /service/app/services/metrics


### PR DESCRIPTION
found this line duplicate
```
 # Copy the source code into the container.
 COPY . /service
```