### PR TITLE
handle error that occurs when the client disconnects while the http.ResponseWriter is about/being to be written to

### DIFF
--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -106,15 +106,21 @@ func (a *App) Handle(method string, group string, path string, handler Handler, 
 
 				// Usually, you get the broken pipe error when you write to the connection after the
 				// RST (TCP RST Flag) is sent.
-				// For example, the client's TCP connection is broken and the server writes to the
-				// connection.
+				// The broken pipe is a TCP/IP error occurring when you write to a stream where the
+				// other end (the peer) has closed the underlying connection. The first write to the
+				// closed connection causes the peer to reply with an RST packet indicating that the
+				// connection should be terminated immediately. The second write to the socket that
+				// has already received the RST causes the broken pipe error.
 				return
 			case errors.Is(err, syscall.ECONNRESET):
 
 				// Usually, you get connection reset by peer error when you read from the
 				// connection after the RST (TCP RST Flag) is sent.
-				// For example, the client's TCP connection is broken while streaming data to/from
-				// the connection.
+				// The connection reset by peer is a TCP/IP error that occurs when the other end (peer)
+				// has unexpectedly closed the connection. It happens when you send a packet from your
+				// end, but the other end crashes and forcibly closes the connection with the RST
+				// packet instead of the TCP FIN, which is used to close a connection under normal
+				// circumstances.
 				return
 			default:
 				a.SignalShutdown()

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -103,12 +103,14 @@ func (a *App) Handle(method string, group string, path string, handler Handler, 
 			// https://gosamples.dev/connection-reset-by-peer/
 			switch {
 			case errors.Is(err, syscall.EPIPE):
+
 				// Usually, you get the broken pipe error when you write to the connection after the
 				// RST (TCP RST Flag) is sent.
 				// For example, the client's TCP connection is broken and the server writes to the
 				// connection.
 				return
 			case errors.Is(err, syscall.ECONNRESET):
+
 				// Usually, you get connection reset by peer error when you read from the
 				// connection after the RST (TCP RST Flag) is sent.
 				// For example, the client's TCP connection is broken while streaming data to/from


### PR DESCRIPTION
Gracefully handle write errors due to the client's connection being disconnected during a large file/data being written to the response at the same time.

`business/web/v1/mid/errors.go` doesn't seem like a good place because of the following:
https://github.com/ardanlabs/service/blob/master/business/web/v1/mid/errors.go#L63-L66
will then call:
https://github.com/ardanlabs/service/blob/master/foundation/web/response.go#L39-L42
which ends up writing to the `http.ResponseWriter` anyways. Hence, when the call stack returns, the common denominator is to have `web.go` handle the error.

This will prevent what would currently cause a signaling of a "shutdown" and causing and outage, and instead, we now catch the error and stop the signaling of the shutdown. We should be "fine" with approach because if a client has terminated its connection, the backend should continue running.