### PR TITLE
remove container leak

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -61,3 +61,4 @@ Wietse Venema <wietsevenema@gmail.com>
 William Kennedy <bill@ardanlabs.com>
 Wyatt Johnson <wyattjoh@gmail.com>
 Zachary Johnson <zachjohnsondev@gmail.com>
+Halil İbrahim Yıldırım <ihalil95@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Ed Gonzo <Ed@ardanstudios.com>
 Erik Straub <erik@straub.dev>
 Farrukh Kurbanov <farrukhkurbanov@Administrators-MacBook-Pro.local>
 Haibin Liu <liu.haibin@gmail.com>
+Halil İbrahim Yıldırım <ihalil95@gmail.com>
 Ioannis Angelakopoulos <ioagel@gmail.com>
 Jacob Walker <jacob@ardanlabs.com>
 Jason Lui <jasonlv@live.com>
@@ -61,4 +62,3 @@ Wietse Venema <wietsevenema@gmail.com>
 William Kennedy <bill@ardanlabs.com>
 Wyatt Johnson <wyattjoh@gmail.com>
 Zachary Johnson <zachjohnsondev@gmail.com>
-Halil İbrahim Yıldırım <ihalil95@gmail.com>

--- a/foundation/docker/docker.go
+++ b/foundation/docker/docker.go
@@ -33,6 +33,7 @@ func StartContainer(image string, port string, args ...string) (*Container, erro
 	id := out.String()[:12]
 	hostIP, hostPort, err := extractIPPort(id, port)
 	if err != nil {
+		StopContainer(id)
 		return nil, fmt.Errorf("could not extract ip/port: %w", err)
 	}
 


### PR DESCRIPTION
when starting a container, for example redis, if there is any typo when passing port argument, StartContainer will produce an error to caller however this image is running in the background we just couldn't extract ip, so as we created this container successfully, we should stop it when an error is happening after container started.