### PR TITLE
Automatically set the GOMAXPROCS from the pods' limits.cpu value

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,11 +32,12 @@ Burhan Khalid <burhan.khalid@gmail.com>
 Ciprian Cimpan <hello@ciprian.pro>
 David Paraschivescu <david.cristian.paraschivescu@gmail.com>
 Denis Nefedov <nefedov.d.d@gmail.com>
-dremnik <61884728+dremnik@users.noreply.github.com>
 Dmytro Tananayskiy <dmitriyminer@gmail.com>
+dremnik <61884728+dremnik@users.noreply.github.com>
 Ed Gonzo <Ed@ardanstudios.com>
 Erik Straub <erik@straub.dev>
 Farrukh Kurbanov <farrukhkurbanov@Administrators-MacBook-Pro.local>
+Florin Pățan <florinpatan@gmail.com>
 Haibin Liu <liu.haibin@gmail.com>
 Halil İbrahim Yıldırım <ihalil95@gmail.com>
 Ioannis Angelakopoulos <ioagel@gmail.com>

--- a/zarf/k8s/base/sales/base-sales.yaml
+++ b/zarf/k8s/base/sales/base-sales.yaml
@@ -15,34 +15,34 @@ spec:
   selector:
     matchLabels:
       app: sales
-  
+
   template:
     metadata:
       labels:
         app: sales
-    
+
     spec:
       terminationGracePeriodSeconds: 60
-      
+
       initContainers:
       - name: init-migrate
         image: sales-api-image
         command: ['./sales-admin', 'migrate']
-      
+
       - name: init-seed
         image: sales-api-image
         command: ['./sales-admin', 'seed']
-      
+
       containers:
       - name: sales-api
         image: sales-api-image
-        
+
         ports:
         - name: sales-api
           containerPort: 3000
         - name: sales-api-debug
           containerPort: 4000
-        
+
         readinessProbe: # readiness probes mark the service available to accept traffic.
           httpGet:
             path: /debug/readiness
@@ -52,7 +52,7 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 2
-        
+
         livenessProbe: # liveness probes mark the service alive or dead (to be restarted).
           httpGet:
             path: /debug/liveness
@@ -62,7 +62,7 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 2
-        
+
         env:
         - name: SALES_DB_HOST
           valueFrom:
@@ -86,15 +86,25 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
 
       - name: metrics
         image: metrics-image
-        
+
         ports:
         - name: metrics
           containerPort: 3001
         - name: metrics-debug
           containerPort: 4001
+
+        env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.cpu
 ---
 apiVersion: v1
 kind: Service

--- a/zarf/k8s/dev/sales/dev-sales-patch-deploy.yaml
+++ b/zarf/k8s/dev/sales/dev-sales-patch-deploy.yaml
@@ -10,7 +10,7 @@ spec:
       app: sales
 
   replicas: 1
-  
+
   strategy:
     type: Recreate
 
@@ -95,12 +95,8 @@ spec:
             cpu: "1000m" # I need access to 1 core on the node.
             memory: 500Mi
           limits:
-            cpu: "1000m" # Execute instructions 100ms/100ms on my 1 core.
+            cpu: "100m" # Execute instructions 100ms/100ms on my 1 core.
             memory: 500Mi
-
-        env:
-        - name: GOMAXPROCS
-          value: "1"
 
         volumeMounts:
           - name: vault
@@ -114,7 +110,3 @@ spec:
           limits:
             cpu: "500m" # Execute instructions 50ms/100ms on my 1/2 core.
             memory: 250Mi
-
-        env:
-        - name: GOMAXPROCS
-          value: "1"


### PR DESCRIPTION
The value is rounded to the next int. E.g. for 2400m GOMAXPROCS will be 3.

More values that can be used can be found here: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/