### PR TITLE
Add curl for telepresence helm install

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,6 +49,7 @@ Jonathan Trinh <jtrinh27@pm.me>
 Leeyong Jing leeyongjing@gmail.com
 liyongjing <liyongjing@users.noreply.github.com>
 Luis Garcia Acosta <lgarciaac@gmail.com>
+Mark Tew <mark.tew@investec.com>
 Michael Gasch <mgasch@vmware.com>
 Nejc BelŠak <belsak@gmail.com>
 Nick Stogner <nstogner@users.noreply.github.com>

--- a/makefile
+++ b/makefile
@@ -150,6 +150,7 @@ GRAFANA         := grafana/grafana:9.5.3
 PROMETHEUS      := prom/prometheus:v2.44.0
 TEMPO           := grafana/tempo:2.1.1
 TELEPRESENCE    := datawire/ambassador-telepresence-manager:2.14.0
+CURL            := curlimages/curl:8.1.1
 
 KIND_CLUSTER    := ardan-starter-cluster
 NAMESPACE       := sales-system
@@ -197,6 +198,7 @@ dev-docker:
 	docker pull $(PROMETHEUS)
 	docker pull $(TEMPO)
 	docker pull $(TELEPRESENCE)
+	docker pull $(CURL)
 
 # ==============================================================================
 # Building containers
@@ -231,6 +233,7 @@ dev-up-local:
 	kubectl wait --timeout=120s --namespace=local-path-storage --for=condition=Available deployment/local-path-provisioner
 
 	kind load docker-image $(TELEPRESENCE) --name $(KIND_CLUSTER)
+	kind load docker-image $(CURL) --name $(KIND_CLUSTER)
 	kind load docker-image $(POSTGRES) --name $(KIND_CLUSTER)
 	kind load docker-image $(VAULT) --name $(KIND_CLUSTER)
 	kind load docker-image $(GRAFANA) --name $(KIND_CLUSTER)


### PR DESCRIPTION
The command `telepresence helm install` runs an init container `curlimages/curl:8.1.1`. Adding this image to the dependency variables and `dev-docker` and `dev-up` commands in the `makefile`