### PR TITLE
Update dev-database.yaml updating pg_hba.conf to allow connection to postgresql server

### DIFF
--- a/zarf/k8s/dev/database/dev-database.yaml
+++ b/zarf/k8s/dev/database/dev-database.yaml
@@ -37,17 +37,29 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: database-data
+        - name: config
+          configMap:
+            name: pghbaconf
+              #defaultMode: 0400
+            items:
+              - key: "pg_hba.conf"
+                path: "pg_hba.conf"
       containers:
       - name: postgres
         image: postgres:15.3
         volumeMounts:
           - name: data
             mountPath: /var/lib/postgresql/data
+          - name: config
+            readOnly: false
+            mountPath: "/etc/pg_hba.conf"
+            subPath: "pg_hba.conf"
         resources:
           requests:
             cpu: "500m" # I need access to 1/2 core on the node.
           limits:
             cpu: "500m" # Execute instructions 50ms/100ms on my 1/2 core.
+        args: ['-c', 'hba_file=/etc/pg_hba.conf']
         env:
         - name: POSTGRES_PASSWORD
           value: postgres
@@ -88,3 +100,23 @@ spec:
   - name: postgres
     port: 5432
     targetPort: postgres
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pghbaconf
+  namespace: sales-system
+data:
+  # file-like keys
+  pg_hba.conf: |
+    local   all             all                                     trust
+    # IPv4 local connections:
+    host    all             all             0.0.0.0/0                trust
+    # IPv6 local connections:
+    host    all             all             ::1/128                 trust
+    # Allow replication connections from localhost, by a user with the
+    # replication privilege.
+    local   replication     all                                     trust
+    host    replication     all             0.0.0.0/0               trust
+    host    replication     all             ::1/128                 trust
+


### PR DESCRIPTION
because connection from pgcli was rejected from 
"clichi@ubuntu-22:~/GO_Course_Ardan_labs/service4.1-video$ pgcli postgresql://postgres:postgres@localhost connection failed: FATAL:  no pg_hba.conf entry for host "172.18.0.1", user "postgres", database "postgres", no encryption" there for pg_hba.conf needs to be modified to allow connection from 0.0.0.0/0 on our case being a dev local one way to fix that was to modify the location adding the args: ['-c', 'hba_file=/etc/pg_hba.conf'] to container start up arguments and create a config map with new file and mount that 
 volumes:
        - name: data
          persistentVolumeClaim:
            claimName: database-data
        - name: config
          configMap:
            name: pghbaconf
              #defaultMode: 0400
            items:
              - key: "pg_hba.conf" path: "pg_hba.conf" containers: - name: postgres image: postgres:15.3 volumeMounts: - name: data mountPath: /var/lib/postgresql/data - name: config readOnly: false mountPath: "/etc/pg_hba.conf" subPath: "pg_hba.conf"

Thanks