### PR TITLE
use one ctx on shutdown for cmd.go

### DIFF
--- a/app/services/sales-api/v1/cmd/cmd.go
+++ b/app/services/sales-api/v1/cmd/cmd.go
@@ -275,7 +275,7 @@ func run(ctx context.Context, log *logger.Logger, build string, routeAdder v1.Ro
 		log.Info(ctx, "shutdown", "status", "shutdown started", "signal", sig)
 		defer log.Info(ctx, "shutdown", "status", "shutdown complete", "signal", sig)
 
-		ctx, cancel := context.WithTimeout(context.Background(), cfg.Web.ShutdownTimeout)
+		ctx, cancel := context.WithTimeout(ctx, cfg.Web.ShutdownTimeout)
 		defer cancel()
 
 		if err := api.Shutdown(ctx); err != nil {


### PR DESCRIPTION
The context should be propagated on shutdown