### PR TITLE
Adding HTTP Shortcut Methods to Routing

### DIFF
--- a/app/services/sales-api/v1/handlers/productgrp/route.go
+++ b/app/services/sales-api/v1/handlers/productgrp/route.go
@@ -37,7 +37,7 @@ func Routes(app *web.App, cfg Config) {
 	ruleAdminOrSubject := mid.AuthorizeProduct(cfg.Auth, auth.RuleAdminOrSubject, prdCore)
 
 	hdl := New(prdCore, usrCore)
-	// app.GET(version, "/products", hdl.Query, authen, ruleAny) example of how to use the app.GET
+	// app.Get(version, "/products", hdl.Query, authen, ruleAny) example of how to use the app.GET
 	app.Handle(http.MethodGet, version, "/products", hdl.Query, authen, ruleAny)
 	app.Handle(http.MethodGet, version, "/products/:product_id", hdl.QueryByID, authen, ruleAdminOrSubject)
 	app.Handle(http.MethodPost, version, "/products", hdl.Create, authen, ruleUserOnly)

--- a/app/services/sales-api/v1/handlers/productgrp/route.go
+++ b/app/services/sales-api/v1/handlers/productgrp/route.go
@@ -37,6 +37,7 @@ func Routes(app *web.App, cfg Config) {
 	ruleAdminOrSubject := mid.AuthorizeProduct(cfg.Auth, auth.RuleAdminOrSubject, prdCore)
 
 	hdl := New(prdCore, usrCore)
+	// app.GET(version, "/products", hdl.Query, authen, ruleAny) example of how to use the app.GET
 	app.Handle(http.MethodGet, version, "/products", hdl.Query, authen, ruleAny)
 	app.Handle(http.MethodGet, version, "/products/:product_id", hdl.QueryByID, authen, ruleAdminOrSubject)
 	app.Handle(http.MethodPost, version, "/products", hdl.Create, authen, ruleUserOnly)

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -155,27 +155,27 @@ func (a *App) Handle(method string, group string, path string, handler Handler, 
 	a.mux.Handle(method, finalPath, h)
 }
 
-// GET is a shortcut for app.Handle(http.MethodGet, path, handler).
+// Get is a shortcut for app.Handle(http.MethodGet, path, handler).
 func (a *App) Get(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodGet, group, path, handler, mw...)
 }
 
-// POST is a shortcut for app.Handle(http.MethodPost, path, handler).
+// Post is a shortcut for app.Handle(http.MethodPost, path, handler).
 func (a *App) Post(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodPost, group, path, handler, mw...)
 }
 
-// PUT is a shortcut for app.Handle(http.MethodPut, path, handler).
+// Put is a shortcut for app.Handle(http.MethodPut, path, handler).
 func (a *App) Put(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodPut, group, path, handler, mw...)
 }
 
-// DELETE is a shortcut for app.Handle(http.MethodDelete, path, handler).
+// Delete is a shortcut for app.Handle(http.MethodDelete, path, handler).
 func (a *App) Delete(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodDelete, group, path, handler, mw...)
 }
 
-// PATCH is a shortcut for app.Handle(http.MethodPatch, path, handler).
+// Patch is a shortcut for app.Handle(http.MethodPatch, path, handler).
 func (a *App) Patch(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodPatch, group, path, handler, mw...)
 }

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -156,27 +156,27 @@ func (a *App) Handle(method string, group string, path string, handler Handler, 
 }
 
 // GET is a shortcut for app.Handle(http.MethodGet, path, handler).
-func (a *App) GET(group string, path string, handler Handler, mw ...Middleware) {
+func (a *App) Get(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodGet, group, path, handler, mw...)
 }
 
 // POST is a shortcut for app.Handle(http.MethodPost, path, handler).
-func (a *App) POST(group string, path string, handler Handler, mw ...Middleware) {
+func (a *App) Post(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodPost, group, path, handler, mw...)
 }
 
 // PUT is a shortcut for app.Handle(http.MethodPut, path, handler).
-func (a *App) PUT(group string, path string, handler Handler, mw ...Middleware) {
+func (a *App) Put(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodPut, group, path, handler, mw...)
 }
 
 // DELETE is a shortcut for app.Handle(http.MethodDelete, path, handler).
-func (a *App) DELETE(group string, path string, handler Handler, mw ...Middleware) {
+func (a *App) Delete(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodDelete, group, path, handler, mw...)
 }
 
 // PATCH is a shortcut for app.Handle(http.MethodPatch, path, handler).
-func (a *App) PATCH(group string, path string, handler Handler, mw ...Middleware) {
+func (a *App) Patch(group string, path string, handler Handler, mw ...Middleware) {
 	a.Handle(http.MethodPatch, group, path, handler, mw...)
 }
 

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -155,6 +155,31 @@ func (a *App) Handle(method string, group string, path string, handler Handler, 
 	a.mux.Handle(method, finalPath, h)
 }
 
+// GET is a shortcut for app.Handle(http.MethodGet, path, handler).
+func (a *App) GET(group string, path string, handler Handler, mw ...Middleware) {
+	a.Handle(http.MethodGet, group, path, handler, mw...)
+}
+
+// POST is a shortcut for app.Handle(http.MethodPost, path, handler).
+func (a *App) POST(group string, path string, handler Handler, mw ...Middleware) {
+	a.Handle(http.MethodPost, group, path, handler, mw...)
+}
+
+// PUT is a shortcut for app.Handle(http.MethodPut, path, handler).
+func (a *App) PUT(group string, path string, handler Handler, mw ...Middleware) {
+	a.Handle(http.MethodPut, group, path, handler, mw...)
+}
+
+// DELETE is a shortcut for app.Handle(http.MethodDelete, path, handler).
+func (a *App) DELETE(group string, path string, handler Handler, mw ...Middleware) {
+	a.Handle(http.MethodDelete, group, path, handler, mw...)
+}
+
+// PATCH is a shortcut for app.Handle(http.MethodPatch, path, handler).
+func (a *App) PATCH(group string, path string, handler Handler, mw ...Middleware) {
+	a.Handle(http.MethodPatch, group, path, handler, mw...)
+}
+
 // =============================================================================
 
 // startSpan initializes the request by adding a span and writing otel


### PR DESCRIPTION
This pull request adds convenient HTTP shortcut methods to the existing routing functionality.

Previously, routing was done using a longer syntax, such as:
`app.Handle(http.MethodGet, version, "/products", hdl.Query, authen, ruleAny)`
With this contribution, you can now use shorter and more expressive syntax like:
`app.Get(version, "/products", hdl.Query, authen, ruleAny)`

The motivation behind this change is to provide a more concise and expressive syntax for routing within the app. This not only enhances readability but also reduces boilerplate code when defining routes.
