### PR TITLE
feat: support podman

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install Go 1.22
           command: |
               sudo rm -rf /usr/local/go
-              wget -O go.tgz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz
+              wget -O go.tgz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz
               sudo tar -C /usr/local -xzf go.tgz
               which go
               go version

--- a/foundation/docker/docker.go
+++ b/foundation/docker/docker.go
@@ -95,6 +95,12 @@ func extractIPPort(id string, port string) (hostIP string, hostPort string, err 
 
 	for _, doc := range docs {
 		if doc.HostIP != "::" {
+			// Podman keeps HostIP empty instead of using 0.0.0.0.
+			// - https://github.com/containers/podman/issues/17780
+			if doc.HostIP == "" {
+				return "localhost", doc.HostPort, nil
+			}
+
 			return doc.HostIP, doc.HostPort, nil
 		}
 	}

--- a/zarf/k8s/dev/sales/kustomization.yaml
+++ b/zarf/k8s/dev/sales/kustomization.yaml
@@ -8,8 +8,8 @@ patches:
   - path: ./dev-sales-patch-service.yaml
 images:
   - name: service-image
-    newName: ardanlabs/service/sales-api
+    newName: localhost/ardanlabs/service/sales-api
     newTag: 0.0.1
   - name: metrics-image
-    newName: ardanlabs/service/sales-api-metrics
+    newName: localhost/ardanlabs/service/sales-api-metrics
     newTag: 0.0.1


### PR DESCRIPTION
This patch adds support for running service using Podman. There are a few notable changes that were required to enable Podman support, described below.

Podman keeps `HostIP` empty instead of using `0.0.0.0`. This behavior required an update to `extractIPPort`. More information in https://github.com/containers/podman/issues/17780.

Podman prefers to use fully-qualified container images (i.e., `example.com/foo/bar:latest`) but will perform [short-name aliasing](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#short-name-aliasing) for unqualified container images. When an unqualified image such as `foo/bar:latest` is loaded into a kind cluster it will be stored as `localhost/foo/bar:latest`.

Using backticks for command substitution isn't POSIX compatible. Switched the backticks to `$()` instead to support alternative shells (e.g., `/bin/fish`).