### PR TITLE
Remove TestGenerateSeed Funcs from business tests

### DIFF
--- a/business/core/tests/home_test.go
+++ b/business/core/tests/home_test.go
@@ -22,6 +22,8 @@ func Test_Home(t *testing.T) {
 
 func homeCrud(t *testing.T) {
 	seed := func(ctx context.Context, userCore *user.Core, homeCore *home.Core) ([]home.Home, error) {
+		hmes := make([]home.Home, 1)
+
 		var filter user.QueryFilter
 		filter.WithName("Admin Gopher")
 
@@ -39,10 +41,25 @@ func homeCrud(t *testing.T) {
 			return nil, fmt.Errorf("seeding user : %w", err)
 		}
 
-		hmes, err := home.TestGenerateSeedHomes(1, homeCore, usr.ID)
-		if err != nil {
-			return nil, fmt.Errorf("seeding homes : %w", err)
+		nh := home.NewHome{
+			UserID: usr.ID,
+			Type:   home.TypeSingle,
+			Address: home.Address{
+				Address1: "Address1",
+				Address2: "Address1",
+				ZipCode:  "12345",
+				City:     "City1",
+				State:    "State1",
+				Country:  "Country1",
+			},
 		}
+
+		hme, err := homeCore.Create(ctx, nh)
+		if err != nil {
+			return nil, fmt.Errorf("seeding home : %w", err)
+		}
+
+		hmes[0] = hme
 
 		return hmes, nil
 	}
@@ -189,6 +206,8 @@ func homeCrud(t *testing.T) {
 
 func homePaging(t *testing.T) {
 	seed := func(ctx context.Context, userCore *user.Core, homeCore *home.Core) ([]home.Home, error) {
+		hmes := make([]home.Home, 2)
+
 		var filter user.QueryFilter
 		filter.WithName("Admin Gopher")
 
@@ -206,10 +225,44 @@ func homePaging(t *testing.T) {
 			return nil, fmt.Errorf("seeding user : %w", err)
 		}
 
-		hmes, err := home.TestGenerateSeedHomes(2, homeCore, usr.ID)
-		if err != nil {
-			return nil, fmt.Errorf("seeding homes : %w", err)
+		nh1 := home.NewHome{
+			UserID: usr.ID,
+			Type:   home.TypeSingle,
+			Address: home.Address{
+				Address1: "Address1",
+				Address2: "Address1",
+				ZipCode:  "12345",
+				City:     "City1",
+				State:    "State1",
+				Country:  "Country1",
+			},
 		}
+
+		hme1, err := homeCore.Create(ctx, nh1)
+		if err != nil {
+			return nil, fmt.Errorf("seeding home 1 : %w", err)
+		}
+
+		nh2 := home.NewHome{
+			UserID: usr.ID,
+			Type:   home.TypeSingle,
+			Address: home.Address{
+				Address1: "Address2",
+				Address2: "Address2",
+				ZipCode:  "67891",
+				City:     "City2",
+				State:    "State2",
+				Country:  "Country2",
+			},
+		}
+
+		hme2, err := homeCore.Create(ctx, nh2)
+		if err != nil {
+			return nil, fmt.Errorf("seeding home 2 : %w", err)
+		}
+
+		hmes[0] = hme1
+		hmes[0] = hme2
 
 		return hmes, nil
 	}

--- a/business/core/tests/product_test.go
+++ b/business/core/tests/product_test.go
@@ -25,6 +25,8 @@ func Test_Product(t *testing.T) {
 
 func productCrud(t *testing.T) {
 	seed := func(ctx context.Context, userCore *user.Core, productCore *product.Core) ([]product.Product, error) {
+		prds := make([]product.Product, 1)
+
 		var filter user.QueryFilter
 		filter.WithName("Admin Gopher")
 
@@ -42,10 +44,19 @@ func productCrud(t *testing.T) {
 			return nil, fmt.Errorf("seeding user : %w", err)
 		}
 
-		prds, err := product.TestGenerateSeedProducts(1, productCore, usr.ID)
-		if err != nil {
-			return nil, fmt.Errorf("seeding products : %w", err)
+		np := product.NewProduct{
+			Name:     "Name1",
+			Cost:     500,
+			Quantity: 10,
+			UserID:   usr.ID,
 		}
+
+		prd, err := productCore.Create(ctx, np)
+		if err != nil {
+			return nil, fmt.Errorf("seeding product : %w", err)
+		}
+
+		prds[0] = prd
 
 		return prds, nil
 	}
@@ -185,6 +196,8 @@ func productCrud(t *testing.T) {
 
 func productPaging(t *testing.T) {
 	seed := func(ctx context.Context, userCore *user.Core, productCore *product.Core) ([]product.Product, error) {
+		prds := make([]product.Product, 2)
+
 		var filter user.QueryFilter
 		filter.WithName("Admin Gopher")
 
@@ -202,10 +215,32 @@ func productPaging(t *testing.T) {
 			return nil, fmt.Errorf("seeding user : %w", err)
 		}
 
-		prds, err := product.TestGenerateSeedProducts(2, productCore, usr.ID)
-		if err != nil {
-			return nil, fmt.Errorf("seeding products : %w", err)
+		np1 := product.NewProduct{
+			Name:     "Name1",
+			Cost:     500,
+			Quantity: 10,
+			UserID:   usr.ID,
 		}
+
+		prd1, err := productCore.Create(ctx, np1)
+		if err != nil {
+			return nil, fmt.Errorf("seeding product 1 : %w", err)
+		}
+
+		np2 := product.NewProduct{
+			Name:     "Name2",
+			Cost:     600,
+			Quantity: 5,
+			UserID:   usr.ID,
+		}
+
+		prd2, err := productCore.Create(ctx, np2)
+		if err != nil {
+			return nil, fmt.Errorf("seeding product 2 : %w", err)
+		}
+
+		prds[0] = prd1
+		prds[1] = prd2
 
 		return prds, nil
 	}

--- a/business/core/tests/vproduct_test.go
+++ b/business/core/tests/vproduct_test.go
@@ -20,6 +20,8 @@ func Test_VProduct(t *testing.T) {
 
 func vproductPaging(t *testing.T) {
 	seed := func(ctx context.Context, userCore *user.Core, productCore *product.Core) ([]product.Product, []user.User, error) {
+		prds := make([]product.Product, 2)
+
 		var filter user.QueryFilter
 		filter.WithName("Admin Gopher")
 
@@ -37,10 +39,32 @@ func vproductPaging(t *testing.T) {
 			return nil, nil, fmt.Errorf("seeding user : %w", err)
 		}
 
-		prds, err := product.TestGenerateSeedProducts(2, productCore, usr.ID)
-		if err != nil {
-			return nil, nil, fmt.Errorf("seeding products : %w", err)
+		np1 := product.NewProduct{
+			Name:     "Name1",
+			Cost:     500,
+			Quantity: 10,
+			UserID:   usr.ID,
 		}
+
+		prd1, err := productCore.Create(ctx, np1)
+		if err != nil {
+			return nil, nil, fmt.Errorf("seeding product 1 : %w", err)
+		}
+
+		np2 := product.NewProduct{
+			Name:     "Name2",
+			Cost:     600,
+			Quantity: 5,
+			UserID:   usr.ID,
+		}
+
+		prd2, err := productCore.Create(ctx, np2)
+		if err != nil {
+			return nil, nil, fmt.Errorf("seeding product 2 : %w", err)
+		}
+
+		prds[0] = prd1
+		prds[1] = prd2
 
 		return prds, []user.User{usr}, nil
 	}


### PR DESCRIPTION
I've made some changes to test functions in business layer for better readability. Here's why:

Consistency: I've used the same method for seeding data in all tests, which makes them easier to follow and maintain.

Clearer Tests: Putting the test data front  improves readability. It's easier to understand what each test is checking.