### PR TITLE
Fix make dev-gotooling

### DIFF
--- a/makefile
+++ b/makefile
@@ -138,9 +138,9 @@ AUTH_IMAGE      := $(BASE_IMAGE_NAME)/$(AUTH_APP):$(VERSION)
 dev-gotooling:
 	go install github.com/divan/expvarmon@latest
 	go install github.com/rakyll/hey@latest
-	go install honnef.co/go/tools/programs/staticcheck@latest
-	go install golang.org/x/vuln/programs/govulncheck@latest
-	go install golang.org/x/tools/programs/goimports@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	go install golang.org/x/tools/cmd/goimports@latest
 
 dev-brew:
 	brew update


### PR DESCRIPTION
Hello, thanks for this starter-kit!

It seems there are typos in `make dev-gotooling` command causing such error:

```
go: honnef.co/go/tools/programs/staticcheck@latest: module honnef.co/go/tools@latest found (v0.4.7), but does not contain package honnef.co/go/tools/programs/staticcheck
make: *** [makefile:141: dev-gotooling] Error 1
```