### PR TITLE
Fix Typo in Comments

### DIFF
--- a/business/domain/homebus/homebus.go
+++ b/business/domain/homebus/homebus.go
@@ -177,7 +177,7 @@ func (b *Business) Count(ctx context.Context, filter QueryFilter) (int, error) {
 	return b.storer.Count(ctx, filter)
 }
 
-// QueryByID finds the home by the specified Ib.
+// QueryByID finds the home by the specified ID.
 func (b *Business) QueryByID(ctx context.Context, homeID uuid.UUID) (Home, error) {
 	hme, err := b.storer.QueryByID(ctx, homeID)
 	if err != nil {
@@ -187,7 +187,7 @@ func (b *Business) QueryByID(ctx context.Context, homeID uuid.UUID) (Home, error
 	return hme, nil
 }
 
-// QueryByUserID finds the homes by a specified User Ib.
+// QueryByUserID finds the homes by a specified User ID.
 func (b *Business) QueryByUserID(ctx context.Context, userID uuid.UUID) ([]Home, error) {
 	hmes, err := b.storer.QueryByUserID(ctx, userID)
 	if err != nil {

--- a/business/domain/productbus/productbus.go
+++ b/business/domain/productbus/productbus.go
@@ -162,7 +162,7 @@ func (b *Business) Count(ctx context.Context, filter QueryFilter) (int, error) {
 	return b.storer.Count(ctx, filter)
 }
 
-// QueryByID finds the product by the specified Ib.
+// QueryByID finds the product by the specified ID.
 func (b *Business) QueryByID(ctx context.Context, productID uuid.UUID) (Product, error) {
 	prd, err := b.storer.QueryByID(ctx, productID)
 	if err != nil {
@@ -172,7 +172,7 @@ func (b *Business) QueryByID(ctx context.Context, productID uuid.UUID) (Product,
 	return prd, nil
 }
 
-// QueryByUserID finds the products by a specified User Ib.
+// QueryByUserID finds the products by a specified User ID.
 func (b *Business) QueryByUserID(ctx context.Context, userID uuid.UUID) ([]Product, error) {
 	prds, err := b.storer.QueryByUserID(ctx, userID)
 	if err != nil {

--- a/business/domain/userbus/userbus.go
+++ b/business/domain/userbus/userbus.go
@@ -166,7 +166,7 @@ func (b *Business) Count(ctx context.Context, filter QueryFilter) (int, error) {
 	return b.storer.Count(ctx, filter)
 }
 
-// QueryByID finds the user by the specified Ib.
+// QueryByID finds the user by the specified ID.
 func (b *Business) QueryByID(ctx context.Context, userID uuid.UUID) (User, error) {
 	user, err := b.storer.QueryByID(ctx, userID)
 	if err != nil {

--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -40,7 +40,6 @@ type App struct {
 
 // NewApp creates an App value that handle a set of routes for the application.
 func NewApp(log Logger, tracer trace.Tracer, mw ...MidFunc) *App {
-
 	// Create an OpenTelemetry HTTP Handler which wraps our router. This will start
 	// the initial span and annotate it with information about the request/trusted.
 	//
@@ -62,7 +61,7 @@ func NewApp(log Logger, tracer trace.Tracer, mw ...MidFunc) *App {
 // ServeHTTP implements the http.Handler interface. It's the entry point for
 // all http traffic and allows the opentelemetry mux to run first to handle
 // tracing. The opentelemetry mux then calls the application mux to handle
-// application traffic. This was set up on line 44 in the NewApp function.
+// application traffic. This was set up in the NewApp function.
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.otmux.ServeHTTP(w, r)
 }


### PR DESCRIPTION
- Fixed a typo in the comments.
- Removed the mention of "on line 44" because the line number reference became incorrect after code changes.
