### PR TITLE
Do not return panic trace in the error message

### DIFF
--- a/app/sdk/mid/panics.go
+++ b/app/sdk/mid/panics.go
@@ -17,7 +17,7 @@ func Panics(ctx context.Context, next HandlerFunc) (resp Encoder) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			trace := debug.Stack()
-			resp = errs.Newf(errs.Internal, "PANIC [%v] TRACE[%s]", rec, string(trace))
+			resp = errs.Newf(errs.InternalOnlyLog, "PANIC [%v] TRACE[%s]", rec, string(trace))
 
 			metrics.AddPanics(ctx)
 		}


### PR DESCRIPTION
When returning `errs.Internal` type of error, whole stack trace gets dumped in the error message. 
This does not seem to me like something intended, so I changed it to a `errs.InternalOnlyLog`, so that trace is only logged, and the api response message contains just `Internal Server Error` message in case if panic occurs. 