### PR TITLE
embed all static files

### DIFF
--- a/api/services/sales/main.go
+++ b/api/services/sales/main.go
@@ -29,7 +29,7 @@ import (
 	Need to figure out timeouts for http service.
 */
 
-//go:embed static
+//go:embed all:static
 var static embed.FS
 
 var build = "develop"


### PR DESCRIPTION
This change will embed static files starting with `.` and `_`. 

From the go [docs](https://pkg.go.dev/embed#hdr-Directives)

> If a pattern begins with the prefix ‘all:’, then the rule for walking directories is changed to include those files beginning with ‘.’ or ‘_’. For example, ‘all:image’ embeds both ‘image/.tempfile’ and ‘image/dir/.tempfile’.
