### PR TITLE
Move queryparams

### DIFF
--- a/app/domain/vproductapp/filter.go
+++ b/app/domain/vproductapp/filter.go
@@ -10,6 +10,17 @@ import (
 	"github.com/google/uuid"
 )
 
+type queryParams struct {
+	Page     string
+	Rows     string
+	OrderBy  string
+	ID       string
+	Name     string
+	Cost     string
+	Quantity string
+	UserName string
+}
+
 func parseQueryParams(r *http.Request) queryParams {
 	values := r.URL.Query()
 

--- a/app/domain/vproductapp/model.go
+++ b/app/domain/vproductapp/model.go
@@ -7,19 +7,6 @@ import (
 	"github.com/ardanlabs/service/business/domain/vproductbus"
 )
 
-type queryParams struct {
-	Page     string
-	Rows     string
-	OrderBy  string
-	ID       string
-	Name     string
-	Cost     string
-	Quantity string
-	UserName string
-}
-
-// =============================================================================
-
 // Product represents information about an individual product with
 // extended information.
 type Product struct {


### PR DESCRIPTION
Moved the `queryparams` struct to be next to the `parseQueryParams` function to maintain consistency with other domains in the app layer. 