### PR TITLE
Error Handling in Validate Function

### DIFF
--- a/app/domain/homeapp/model.go
+++ b/app/domain/homeapp/model.go
@@ -91,7 +91,7 @@ func (app *NewHome) Decode(data []byte) error {
 // Validate checks if the data in the model is considered clean.
 func (app NewHome) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil
@@ -150,7 +150,7 @@ func (app *UpdateHome) Decode(data []byte) error {
 // Validate checks the data in the model is considered clean.
 func (app UpdateHome) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil

--- a/app/domain/productapp/model.go
+++ b/app/domain/productapp/model.go
@@ -69,7 +69,7 @@ func (app *NewProduct) Decode(data []byte) error {
 // Validate checks the data in the model is considered clean.
 func (app NewProduct) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil
@@ -123,7 +123,7 @@ func (app *UpdateProduct) Decode(data []byte) error {
 // Validate checks the data in the model is considered clean.
 func (app UpdateProduct) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil

--- a/app/domain/tranapp/model.go
+++ b/app/domain/tranapp/model.go
@@ -56,7 +56,7 @@ type NewTran struct {
 // Validate checks the data in the model is considered clean.
 func (app NewTran) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil
@@ -82,7 +82,7 @@ type NewUser struct {
 // Validate checks the data in the model is considered clean.
 func (app NewUser) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil
@@ -132,7 +132,7 @@ type NewProduct struct {
 // Validate checks the data in the model is considered clean.
 func (app NewProduct) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil

--- a/app/domain/userapp/model.go
+++ b/app/domain/userapp/model.go
@@ -74,7 +74,7 @@ func (app *NewUser) Decode(data []byte) error {
 // Validate checks the data in the model is considered clean.
 func (app NewUser) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil
@@ -127,7 +127,7 @@ func (app *UpdateUserRole) Decode(data []byte) error {
 // Validate checks the data in the model is considered clean.
 func (app UpdateUserRole) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil
@@ -170,7 +170,7 @@ func (app *UpdateUser) Decode(data []byte) error {
 // Validate checks the data in the model is considered clean.
 func (app UpdateUser) Validate() error {
 	if err := errs.Check(app); err != nil {
-		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+		return fmt.Errorf("validate: %w", err)
 	}
 
 	return nil

--- a/app/sdk/errs/validate.go
+++ b/app/sdk/errs/validate.go
@@ -1,6 +1,7 @@
 package errs
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 
@@ -48,10 +49,10 @@ func Check(val any) error {
 
 		var fields FieldErrors
 		for _, verror := range verrors {
-			fields = append(fields, FieldError{
-				Field: verror.Field(),
-				Err:   verror.Translate(translator),
-			})
+			fields.Add(
+				verror.Field(),
+				errors.New(verror.Translate(translator)),
+			)
 		}
 
 		return fields


### PR DESCRIPTION
In the first commit, I used the newly added `Add` method of `FieldErrors` to append errors to the collection.

I'm not sure if I'm doing the right thing in the second commit. Since we're using the result of `Validate` function inside `web.Decode` function, and eventually this result is used at the app layer&mdash;like what comes next&mdash; I thought we could've wrapped any intermediate errors  and only then at the `app` layer, put them inside an `errs.Error`:

```go
       func (a *app) create(ctx context.Context, r *http.Request) web.Encoder {
	    ...
	    
	    if err := web.Decode(r, &app); err != nil {
	    	    return errs.New(errs.InvalidArgument, err)
	    }
	    
	    ...
        }
```