### PR TITLE
Duplicated TraceProviderOption

### DIFF
--- a/foundation/otel/otel.go
+++ b/foundation/otel/otel.go
@@ -63,7 +63,6 @@ func InitTracing(log *logger.Logger, cfg Config) (trace.TracerProvider, func(ctx
 			sdktrace.WithBatcher(exporter,
 				sdktrace.WithMaxExportBatchSize(sdktrace.DefaultMaxExportBatchSize),
 				sdktrace.WithBatchTimeout(sdktrace.DefaultScheduleDelay*time.Millisecond),
-				sdktrace.WithMaxExportBatchSize(sdktrace.DefaultMaxExportBatchSize),
 			),
 			sdktrace.WithResource(
 				resource.NewWithAttributes(

--- a/foundation/otel/otel.go
+++ b/foundation/otel/otel.go
@@ -116,9 +116,7 @@ func AddSpan(ctx context.Context, spanName string, keyValues ...attribute.KeyVal
 	}
 
 	ctx, span := v.Start(ctx, spanName)
-	for _, kv := range keyValues {
-		span.SetAttributes(kv)
-	}
+	span.SetAttributes(keyValues...)
 
 	return ctx, span
 }

--- a/foundation/web/context.go
+++ b/foundation/web/context.go
@@ -26,9 +26,7 @@ func addSpan(ctx context.Context, spanName string, keyValues ...attribute.KeyVal
 	}
 
 	ctx, span := v.Start(ctx, spanName)
-	for _, kv := range keyValues {
-		span.SetAttributes(kv)
-	}
+	span.SetAttributes(keyValues...)
 
 	return ctx, span
 }


### PR DESCRIPTION
This MR removes duplicated option sent to `sdktrace.WithBatcher()` function.