### PR TITLE
Remove Duplicated CORS Logic

### DIFF
--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -154,14 +154,6 @@ func (a *App) HandlerFunc(method string, group string, path string, handlerFunc 
 
 		otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(w.Header()))
 
-		reqOrigin := r.Header.Get("Origin")
-		for _, origin := range a.origins {
-			if origin == "*" || origin == reqOrigin {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-				break
-			}
-		}
-
 		resp := handlerFunc(ctx, r)
 
 		if err := Respond(ctx, w, resp); err != nil {


### PR DESCRIPTION
We've already been handling CORS logic at [web.go:147](https://github.com/ardanlabs/service/blob/1fddab71862770ede5781cb7417b09a7c71a064f/foundation/web/web.go#L147) using a middleware. So I removed the part which was repeating the same logic. 