### PR TITLE
chore: removed deprecated DualStack of net.Dialer in authclient sdk

### DIFF
--- a/app/sdk/authclient/authclient.go
+++ b/app/sdk/authclient/authclient.go
@@ -22,13 +22,13 @@ import (
 // This provides a default client configuration, but it's recommended
 // this is replaced by the user with application specific settings using
 // the WithClient function at the time a AuthAPI is constructed.
+// DualStack Deprecated: Fast Fallback is enabled by default. To disable, set FallbackDelay to a negative value.
 var defaultClient = http.Client{
 	Transport: &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 15 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,


### PR DESCRIPTION
removed deprecated DualStack of net.Dialer in authclient sdk and added comments.
Reference:

[net.Dialer pkg.go.dev](https://pkg.go.dev/net#Dialer):
```
// DualStack previously enabled [RFC 6555](https://rfc-editor.org/rfc/rfc6555.html) Fast Fallback
// support, also known as "Happy Eyeballs", in which IPv4 is
// tried soon if IPv6 appears to be misconfigured and
// hanging.
//
// Deprecated: Fast Fallback is enabled by default. To
// disable, set FallbackDelay to a negative value.
DualStack [bool](https://pkg.go.dev/builtin#bool)

// FallbackDelay specifies the length of time to wait before
// spawning a [RFC 6555](https://rfc-editor.org/rfc/rfc6555.html) Fast Fallback connection. That is, this
// is the amount of time to wait for IPv6 to succeed before
// assuming that IPv6 is misconfigured and falling back to
// IPv4.
//
// If zero, a default delay of 300ms is used.
// A negative value disables Fast Fallback support.
FallbackDelay [time](https://pkg.go.dev/time).[Duration](https://pkg.go.dev/time#Duration)
```