### PR TITLE
Increase Test Coverage

### DIFF
--- a/api/services/sales/tests/homeapi/home_test.go
+++ b/api/services/sales/tests/homeapi/home_test.go
@@ -21,6 +21,7 @@ func Test_Home(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	test.Run(t, query200(sd), "query-200")
+	test.Run(t, query400(sd), "query-400")
 	test.Run(t, queryByID200(sd), "querybyid-200")
 
 	test.Run(t, create200(sd), "create-200")

--- a/api/services/sales/tests/homeapi/query_test.go
+++ b/api/services/sales/tests/homeapi/query_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ardanlabs/service/app/domain/homeapp"
 	"github.com/ardanlabs/service/app/sdk/apitest"
+	"github.com/ardanlabs/service/app/sdk/errs"
 	"github.com/ardanlabs/service/app/sdk/query"
 	"github.com/ardanlabs/service/business/domain/homebus"
 	"github.com/google/go-cmp/cmp"
@@ -35,6 +36,37 @@ func query200(sd apitest.SeedData) []apitest.Table {
 				Total:       len(hmes),
 				Items:       toAppHomes(hmes),
 			},
+			CmpFunc: func(got any, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+
+	return table
+}
+
+func query400(sd apitest.SeedData) []apitest.Table {
+	table := []apitest.Table{
+		{
+			Name:       "bad-query-filter",
+			URL:        "/v1/homes?page=1&rows=10&type=bungalow",
+			Token:      sd.Users[0].Token,
+			StatusCode: http.StatusBadRequest,
+			Method:     http.MethodGet,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.InvalidArgument, "[{\"field\":\"type\",\"error\":\"invalid home type \\\"bungalow\\\"\"}]"),
+			CmpFunc: func(got any, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-orderby-value",
+			URL:        "/v1/homes?page=1&rows=10&orderBy=ome_id,ASC",
+			Token:      sd.Users[0].Token,
+			StatusCode: http.StatusBadRequest,
+			Method:     http.MethodGet,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.InvalidArgument, "[{\"field\":\"order\",\"error\":\"unknown order: ome_id\"}]"),
 			CmpFunc: func(got any, exp any) string {
 				return cmp.Diff(got, exp)
 			},

--- a/api/services/sales/tests/productapi/product_test.go
+++ b/api/services/sales/tests/productapi/product_test.go
@@ -21,6 +21,7 @@ func Test_Product(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	test.Run(t, query200(sd), "query-200")
+	test.Run(t, query400(sd), "query-400")
 	test.Run(t, queryByID200(sd), "querybyid-200")
 
 	test.Run(t, create200(sd), "create-200")

--- a/api/services/sales/tests/productapi/query_test.go
+++ b/api/services/sales/tests/productapi/query_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ardanlabs/service/app/domain/productapp"
 	"github.com/ardanlabs/service/app/sdk/apitest"
+	"github.com/ardanlabs/service/app/sdk/errs"
 	"github.com/ardanlabs/service/app/sdk/query"
 	"github.com/ardanlabs/service/business/domain/productbus"
 	"github.com/google/go-cmp/cmp"
@@ -35,6 +36,37 @@ func query200(sd apitest.SeedData) []apitest.Table {
 				Total:       len(prds),
 				Items:       toAppProducts(prds),
 			},
+			CmpFunc: func(got any, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+
+	return table
+}
+
+func query400(sd apitest.SeedData) []apitest.Table {
+	table := []apitest.Table{
+		{
+			Name:       "bad-query-filter",
+			URL:        "/v1/products?page=1&rows=10&name=$#!",
+			Token:      sd.Admins[0].Token,
+			StatusCode: http.StatusBadRequest,
+			Method:     http.MethodGet,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.InvalidArgument, "[{\"field\":\"name\",\"error\":\"invalid name \\\"$#!\\\"\"}]"),
+			CmpFunc: func(got any, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-orderby-value",
+			URL:        "/v1/products?page=1&rows=10&orderBy=roduct_id,ASC",
+			Token:      sd.Admins[0].Token,
+			StatusCode: http.StatusBadRequest,
+			Method:     http.MethodGet,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.InvalidArgument, "[{\"field\":\"order\",\"error\":\"unknown order: roduct_id\"}]"),
 			CmpFunc: func(got any, exp any) string {
 				return cmp.Diff(got, exp)
 			},

--- a/api/services/sales/tests/userapi/user_test.go
+++ b/api/services/sales/tests/userapi/user_test.go
@@ -21,6 +21,7 @@ func Test_User(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	test.Run(t, query200(sd), "query-200")
+	test.Run(t, query400(sd), "query-400")
 	test.Run(t, queryByID200(sd), "querybyid-200")
 
 	test.Run(t, create200(sd), "create-200")

--- a/api/services/sales/tests/vproductapi/query_test.go
+++ b/api/services/sales/tests/vproductapi/query_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ardanlabs/service/app/domain/vproductapp"
 	"github.com/ardanlabs/service/app/sdk/apitest"
+	"github.com/ardanlabs/service/app/sdk/errs"
 	"github.com/ardanlabs/service/app/sdk/query"
 	"github.com/google/go-cmp/cmp"
 )
@@ -32,6 +33,37 @@ func query200(sd apitest.SeedData) []apitest.Table {
 				Total:       len(prds),
 				Items:       prds,
 			},
+			CmpFunc: func(got any, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+
+	return table
+}
+
+func query400(sd apitest.SeedData) []apitest.Table {
+	table := []apitest.Table{
+		{
+			Name:       "bad-query-filter",
+			URL:        "/v1/vproducts?page=1&rows=10&name=$#!",
+			Token:      sd.Admins[0].Token,
+			StatusCode: http.StatusBadRequest,
+			Method:     http.MethodGet,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.InvalidArgument, "[{\"field\":\"name\",\"error\":\"invalid name \\\"$#!\\\"\"}]"),
+			CmpFunc: func(got any, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-orderby-value",
+			URL:        "/v1/vproducts?page=1&rows=10&orderBy=roduct_id,ASC",
+			Token:      sd.Admins[0].Token,
+			StatusCode: http.StatusBadRequest,
+			Method:     http.MethodGet,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.InvalidArgument, "[{\"field\":\"order\",\"error\":\"unknown order: roduct_id\"}]"),
 			CmpFunc: func(got any, exp any) string {
 				return cmp.Diff(got, exp)
 			},

--- a/api/services/sales/tests/vproductapi/vproduct_test.go
+++ b/api/services/sales/tests/vproductapi/vproduct_test.go
@@ -21,4 +21,5 @@ func Test_VProduct(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	test.Run(t, query200(sd), "query-200")
+	test.Run(t, query400(sd), "query-400")
 }


### PR DESCRIPTION
Added missing tests to cover 400 scenarios when given malformed query params.
This is originally mentioned at [#443](https://github.com/ardanlabs/service/issues/443#issuecomment-2541594859):

> We need some tests to cover query filters. I though I had them so when the tests passed I thought I was good. What a classic mistake :( 

