### PR TITLE
fix(queryParams): change "row" to "rows" in query params

### DIFF
--- a/app/domain/homeapp/filter.go
+++ b/app/domain/homeapp/filter.go
@@ -26,7 +26,7 @@ func parseQueryParams(r *http.Request) queryParams {
 
 	filter := queryParams{
 		Page:             values.Get("page"),
-		Rows:             values.Get("row"),
+		Rows:             values.Get("rows"),
 		OrderBy:          values.Get("orderBy"),
 		ID:               values.Get("home_id"),
 		UserID:           values.Get("user_id"),

--- a/app/domain/productapp/filter.go
+++ b/app/domain/productapp/filter.go
@@ -25,7 +25,7 @@ func parseQueryParams(r *http.Request) queryParams {
 
 	filter := queryParams{
 		Page:     values.Get("page"),
-		Rows:     values.Get("row"),
+		Rows:     values.Get("rows"),
 		OrderBy:  values.Get("orderBy"),
 		ID:       values.Get("product_id"),
 		Name:     values.Get("name"),

--- a/app/domain/userapp/filter.go
+++ b/app/domain/userapp/filter.go
@@ -27,7 +27,7 @@ func parseQueryParams(r *http.Request) (queryParams, error) {
 
 	filter := queryParams{
 		Page:             values.Get("page"),
-		Rows:             values.Get("row"),
+		Rows:             values.Get("rows"),
 		OrderBy:          values.Get("orderBy"),
 		ID:               values.Get("user_id"),
 		Name:             values.Get("name"),

--- a/app/domain/vproductapp/filter.go
+++ b/app/domain/vproductapp/filter.go
@@ -26,7 +26,7 @@ func parseQueryParams(r *http.Request) queryParams {
 
 	filter := queryParams{
 		Page:     values.Get("page"),
-		Rows:     values.Get("row"),
+		Rows:     values.Get("rows"),
 		OrderBy:  values.Get("orderBy"),
 		ID:       values.Get("product_id"),
 		Name:     values.Get("name"),


### PR DESCRIPTION
There was an issue with `make load` command which rows=2 not worked properly and returned 10 rows default.