### PR TITLE
Error handling improvements

### DIFF
--- a/app/sdk/auth/auth.go
+++ b/app/sdk/auth/auth.go
@@ -122,12 +122,12 @@ func (a *Auth) Authenticate(ctx context.Context, bearerToken string) (Claims, er
 
 	kidRaw, exists := token.Header["kid"]
 	if !exists {
-		return Claims{}, fmt.Errorf("kid missing from header: %w", err)
+		return Claims{}, errors.New("kid missing from header")
 	}
 
 	kid, ok := kidRaw.(string)
 	if !ok {
-		return Claims{}, fmt.Errorf("kid malformed: %w", err)
+		return Claims{}, errors.New("kid malformed")
 	}
 
 	pem, err := a.keyLookup.PublicKey(kid)


### PR DESCRIPTION
This pull request includes changes to the `Authenticate` method in the `auth.go` file to improve error handling by removing unnecessary error wrapping. 

Error handling improvements:

* [`app/sdk/auth/auth.go`](diffhunk://#diff-a9ea36481325de4a7eb18b87a3dae7a8f3d7d4718c01905015be9a77f0e012b0L125-R130): Modified the `Authenticate` method to return plain error messages instead of wrapping errors with `fmt.Errorf` when the `kid` is missing or malformed.