### PR TITLE
fix typos

### DIFF
--- a/app/sdk/errs/codes.go
+++ b/app/sdk/errs/codes.go
@@ -107,7 +107,7 @@ var (
 	// authentication credentials for the operation.
 	Unauthenticated = ErrCode{value: 17}
 
-	// TooManyRequest indicates that the client has made too many requests and
+	// TooManyRequests indicates that the client has made too many requests and
 	// exceeded their rate limit and/or quota and must wait before making
 	// futhur requests.
 	TooManyRequests = ErrCode{value: 18}

--- a/foundation/web/response.go
+++ b/foundation/web/response.go
@@ -18,7 +18,7 @@ func NewNoResponse() NoResponse {
 	return NoResponse{}
 }
 
-// Encode implements the Encoder interface
+// Encode implements the Encoder interface.
 func (NoResponse) Encode() ([]byte, string, error) {
 	return nil, "", nil
 }

--- a/foundation/worker/worker.go
+++ b/foundation/worker/worker.go
@@ -119,7 +119,7 @@ func (w *Worker) Start(ctx context.Context, jobFn JobFn) (string, error) {
 	w.wg.Add(1)
 	go func() {
 
-		// Do this in a separate defer incase the other defer panics.
+		// Do this in a separate defer in case the other defer panics.
 		// This adds a value back to the semaphore allowing a new message
 		// to be processed.
 		defer func() { w.sem <- true }()
@@ -132,7 +132,7 @@ func (w *Worker) Start(ctx context.Context, jobFn JobFn) (string, error) {
 			w.wg.Done()
 		}()
 
-		// Execute the actually workload.
+		// Execute the actual workload.
 		jobFn(ctx)
 	}()
 


### PR DESCRIPTION
Fix typo that causes mismatch between var and its documentation. Add missing period. Fix two grammatical errors.