### PR TITLE
fix(tempo): added hostname and endpoints to support connections in 2.7.0

### DIFF
--- a/zarf/k8s/dev/tempo/dev-tempo.yaml
+++ b/zarf/k8s/dev/tempo/dev-tempo.yaml
@@ -19,16 +19,18 @@ data:
     distributor:
       receivers: # this configuration will listen on all ports and protocols that tempo is capable of.
         #jaeger: # the receives all come from the OpenTelemetry collector.  more configuration information can
-          #protocols: # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
-            #thrift_http:                   #
-            #grpc:                          # for a production deployment you should only enable the receivers you need!
-            #thrift_binary:
-            #thrift_compact:
+        #protocols: # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        #thrift_http:                   #
+        #grpc:                          # for a production deployment you should only enable the receivers you need!
+        #thrift_binary:
+        #thrift_compact:
         #zipkin:
         otlp:
           protocols:
             http:
+              endpoint: "tempo:4318"
             grpc:
+              endpoint: "tempo:4317"
         #opencensus:
 
     ingester:
@@ -93,6 +95,7 @@ spec:
       labels:
         app: tempo
     spec:
+      hostname: tempo
       containers:
         - image: grafana/tempo:2.7.0
           name: tempo


### PR DESCRIPTION
I discovered the issue when there was no tracing in Tempo after upgrading to 2.7.0. This pull request addresses the issue where the OpenTelemetry Collector receiver defaults to binding on `localhost` instead of `0.0.0.0` after upgrading to version 2.7.0. As a result of this change, Tempo installations running in Docker or other container environments must update their listener addresses to continue receiving data.

**Background:**

- Issue: [#4465](https://github.com/open-telemetry/opentelemetry-collector/issues/4465)
- ChangeLog: [#Upgrade_Considerations](https://grafana.com/docs/tempo/latest/release-notes/v2-7/#opentelemetry-collector-receiver-listens-on-localhost-by-default)
- After the upgrade, the receivers now default to `localhost:4317` and `localhost:4318` instead of `0.0.0.0:4317` and `0.0.0.0:4318`.

**Problem:**

Most Tempo installations use the receivers with the default configuration:

```yaml
distributor:
  receivers:
    otlp:
      protocols:
        grpc:
        http:
```

With the changes to replace unspecified addresses, the receivers now default to `localhost:4317` and `localhost:4318`. As a result, connections to Tempo running in a Docker container won’t work anymore.

**Solution:**

To resolve this issue, the listener address needs to be explicitly specified. This pull request adds the hostname and endpoints to the Tempo configuration to ensure proper connections in Docker environments.

**Example Configuration:**

1. **Using Hostname:**

```yaml
distributor:
  receivers:
    otlp:
      protocols:
        grpc:
        http:
          endpoint: "tempo:4318"
```

2. **Binding to `0.0.0.0`:**

```yaml
distributor:
  receivers:
    otlp:
      protocols:
        grpc:
        http:
          endpoint: "0.0.0.0:4318"
```

**Security Considerations:**

Binding to `0.0.0.0` has potential security risks, as it allows connections from any IP address. It's recommended to use specific hostnames where possible to enhance security.

**Testing:**

- Verified that the receiver binds to the specified address.
- Ensured that data is received correctly in Tempo when running in Kubernetes environments.
