### PR TITLE
fix(dependencies): Ensure compatibility brew dependencies with newer images

### DIFF
--- a/makefile
+++ b/makefile
@@ -149,6 +149,9 @@ dev-brew:
 	brew list pgcli || brew install pgcli
 	brew list watch || brew install watch
 
+dev-brew-upgrade:
+	brew upgrade
+
 dev-docker:
 	docker pull $(GOLANG) & \
 	docker pull $(ALPINE) & \
@@ -248,7 +251,7 @@ dev-restart:
 	kubectl rollout restart deployment $(AUTH_APP) --namespace=$(NAMESPACE)
 	kubectl rollout restart deployment $(SALES_APP) --namespace=$(NAMESPACE)
 
-dev-run: build dev-up dev-load dev-apply
+dev-run: dev-brew-upgrade build dev-up dev-load dev-apply
 
 dev-update: build dev-load dev-restart
 
@@ -576,6 +579,7 @@ help:
 	@echo "Commands:"
 	@echo "  dev-gotooling           Install Go tooling"
 	@echo "  dev-brew                Install brew dependencies"
+	@echo "  dev-brew-upgrade        Upgrade brew dependencies"
 	@echo "  dev-docker              Pull Docker images"
 	@echo "  build                   Build all the containers"
 	@echo "  sales                   Build the sales container"


### PR DESCRIPTION
This PR upgrades brew dependencies to ensure compatibility with newer image versions, for example kind CLI with kindest/node latest image, v1.33.1. This resolves the 

> ERROR: failed to detect containerd snapshotter

 error that occurs during kind load docker-image operations.

**Why is this change needed? 🤔**

When using kind CLI 0.26.0 to create a cluster with a newer node image like kindest/node:v1.33.1, any attempt to load an image fails with the following error:

```
$ kind load docker-image my-image:latest --name my-cluster

ERROR: failed to detect containerd snapshotter
```
This is caused by a change in the containerd version or its default configuration within the v1.33.1 node image. The snapshotter discovery mechanism in kind 0.26.0 is unable to correctly parse the containerd plugin information or identify the default snapshotter (e.g., overlayfs), causing all image loading operations to fail while latest version of kind CLI is 0.29.0.

This prevents users from pre-loading images, forcing nodes to pull them from a remote registry, which slows down local development and can be problematic in offline environments.

### **_How does this change address the issue? 🚀_**

This change improves the reliability and consistency of the local development environment by automating dependency management.

**Automated Dependency Upgrades**
The main `dev-run` command has been updated to first run `dev-brew-upgrade`. This ensures that every time a developer runs the project, all of their Homebrew-managed tools are automatically upgraded to the latest versions. This proactively prevents bugs and build failures caused by outdated dependencies.

**Improved Discoverability**
Finally, the new `dev-brew-upgrade` command has been added to the help output, making the new functionality clear to all developers on the team and documenting the improved workflow.
