### PR TITLE
Refactor sampler to use combined `url.path` and `url.query` for endpoint matching.

### DIFF
--- a/foundation/otel/sampler.go
+++ b/foundation/otel/sampler.go
@@ -31,7 +31,7 @@ func endpoint(parameters trace.SamplingParameters) (string, error) {
 	}
 
 	if path == "" {
-		return "", errors.New("url.path missing in span attribute")
+		return "", errors.New("url.path missing in span attributes")
 	}
 
 	if query == "" {

--- a/foundation/otel/sampler.go
+++ b/foundation/otel/sampler.go
@@ -28,8 +28,8 @@ func endpoint(parameters trace.SamplingParameters) string {
 		}
 	}
 
-	if path != "" && query != "" {
-		path += "?" + query
+	if query != "" && path != "" {
+		return path + "?" + query
 	}
 
 	return path

--- a/foundation/otel/sampler.go
+++ b/foundation/otel/sampler.go
@@ -16,14 +16,31 @@ func newEndpointExcluder(endpoints map[string]struct{}, probability float64) end
 	}
 }
 
+func endpoint(parameters trace.SamplingParameters) string {
+	var path, query string
+
+	for _, attr := range parameters.Attributes {
+		switch attr.Key {
+		case "url.path":
+			path = attr.Value.AsString()
+		case "url.query":
+			query = attr.Value.AsString()
+		}
+	}
+
+	if path != "" && query != "" {
+		path += "?" + query
+	}
+
+	return path
+}
+
 // ShouldSample implements the sampler interface. It prevents the specified
 // endpoints from being added to the trace.
 func (ee endpointExcluder) ShouldSample(parameters trace.SamplingParameters) trace.SamplingResult {
-	for i := range parameters.Attributes {
-		if parameters.Attributes[i].Key == "http.target" {
-			if _, exists := ee.endpoints[parameters.Attributes[i].Value.AsString()]; exists {
-				return trace.SamplingResult{Decision: trace.Drop}
-			}
+	if ep := endpoint(parameters); ep != "" {
+		if _, exists := ee.endpoints[ep]; exists {
+			return trace.SamplingResult{Decision: trace.Drop}
 		}
 	}
 


### PR DESCRIPTION
HTTP semantic conventions changed.
http.target attribute was split into two attributes, url.path and url.query.

https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/http/http-spans.md#http-client-server-example