### PR TITLE
fix: handle specific application OK error case in isError function

### DIFF
--- a/app/sdk/mid/mid.go
+++ b/app/sdk/mid/mid.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/ardanlabs/service/app/sdk/auth"
+	"github.com/ardanlabs/service/app/sdk/errs"
 	"github.com/ardanlabs/service/business/domain/homebus"
 	"github.com/ardanlabs/service/business/domain/productbus"
 	"github.com/ardanlabs/service/business/domain/userbus"
@@ -18,6 +19,10 @@ import (
 func isError(e web.Encoder) error {
 	err, isError := e.(error)
 	if isError {
+		var appErr *errs.Error
+		if errors.As(err, &appErr) && appErr.Code == errs.OK {
+			return nil
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
This is a tiny improvement to the application errs. There is an error enum called `OK` and it just get log as error which is not right. More importantly if you have a transaction middleware and you return this error the transaction will get rollback which is not correct as well.

I could be using this wrong but this is the way I'm returning 200 OK without making a struct conforming to the `web.Encoder` interface.