### PR TITLE
fix: eliminate nil receiver warnings in filter parseFilter functions Initialize FieldErrors as empty slice instead of nil across all domain filters

### DIFF
--- a/app/domain/auditapp/filter.go
+++ b/app/domain/auditapp/filter.go
@@ -44,7 +44,7 @@ func parseQueryParams(r *http.Request) (queryParams, error) {
 }
 
 func parseFilter(qp queryParams) (auditbus.QueryFilter, error) {
-	var fieldErrors errs.FieldErrors
+	var fieldErrors = make(errs.FieldErrors, 0)
 	var filter auditbus.QueryFilter
 
 	if qp.ObjID != "" {
@@ -111,7 +111,7 @@ func parseFilter(qp queryParams) (auditbus.QueryFilter, error) {
 		}
 	}
 
-	if fieldErrors != nil {
+	if len(fieldErrors) > 0 {
 		return auditbus.QueryFilter{}, fieldErrors.ToError()
 	}
 

--- a/app/domain/homeapp/filter.go
+++ b/app/domain/homeapp/filter.go
@@ -39,7 +39,7 @@ func parseQueryParams(r *http.Request) queryParams {
 }
 
 func parseFilter(qp queryParams) (homebus.QueryFilter, error) {
-	var fieldErrors errs.FieldErrors
+	var fieldErrors = make(errs.FieldErrors, 0)
 	var filter homebus.QueryFilter
 
 	if qp.ID != "" {
@@ -92,7 +92,7 @@ func parseFilter(qp queryParams) (homebus.QueryFilter, error) {
 		}
 	}
 
-	if fieldErrors != nil {
+	if len(fieldErrors) > 0 {
 		return homebus.QueryFilter{}, fieldErrors.ToError()
 	}
 

--- a/app/domain/productapp/filter.go
+++ b/app/domain/productapp/filter.go
@@ -37,7 +37,7 @@ func parseQueryParams(r *http.Request) queryParams {
 }
 
 func parseFilter(qp queryParams) (productbus.QueryFilter, error) {
-	var fieldErrors errs.FieldErrors
+	var fieldErrors = make(errs.FieldErrors, 0)
 	var filter productbus.QueryFilter
 
 	if qp.ID != "" {
@@ -81,7 +81,7 @@ func parseFilter(qp queryParams) (productbus.QueryFilter, error) {
 		}
 	}
 
-	if fieldErrors != nil {
+	if len(fieldErrors) > 0 {
 		return productbus.QueryFilter{}, fieldErrors.ToError()
 	}
 

--- a/app/domain/userapp/filter.go
+++ b/app/domain/userapp/filter.go
@@ -40,7 +40,7 @@ func parseQueryParams(r *http.Request) (queryParams, error) {
 }
 
 func parseFilter(qp queryParams) (userbus.QueryFilter, error) {
-	var fieldErrors errs.FieldErrors
+	var fieldErrors = make(errs.FieldErrors, 0)
 	var filter userbus.QueryFilter
 
 	if qp.ID != "" {
@@ -93,7 +93,7 @@ func parseFilter(qp queryParams) (userbus.QueryFilter, error) {
 		}
 	}
 
-	if fieldErrors != nil {
+	if len(fieldErrors) > 0 {
 		return userbus.QueryFilter{}, fieldErrors.ToError()
 	}
 

--- a/app/domain/vproductapp/filter.go
+++ b/app/domain/vproductapp/filter.go
@@ -39,7 +39,7 @@ func parseQueryParams(r *http.Request) queryParams {
 }
 
 func parseFilter(qp queryParams) (vproductbus.QueryFilter, error) {
-	var fieldErrors errs.FieldErrors
+	var fieldErrors = make(errs.FieldErrors, 0)
 	var filter vproductbus.QueryFilter
 
 	if qp.ID != "" {
@@ -93,7 +93,7 @@ func parseFilter(qp queryParams) (vproductbus.QueryFilter, error) {
 		}
 	}
 
-	if fieldErrors != nil {
+	if len(fieldErrors) > 0 {
 		return vproductbus.QueryFilter{}, fieldErrors.ToError()
 	}
 


### PR DESCRIPTION
This PR fixes filters: initializes FieldErrors as empty slice to prevent nil receiver warnings

- Replace `var fieldErrors errs.FieldErrors` with `make(errs.FieldErrors, 0)`
- Update nil checks to use `len(fieldErrors) > 0` instead of `!= nil`
- Applied across auditapp, productapp, userapp, homeapp, and vproductapp filters
- Eliminates linter warnings about calling methods on potentially nil receivers