### PR TITLE
fix: Return NotFound instead of Unauthenticated for missing resources

### DIFF
--- a/app/sdk/mid/authorize.go
+++ b/app/sdk/mid/authorize.go
@@ -72,7 +72,7 @@ func AuthorizeUser(client *authclient.Client, userBus userbus.ExtBusiness, rule 
 				if err != nil {
 					switch {
 					case errors.Is(err, userbus.ErrNotFound):
-						return errs.New(errs.Unauthenticated, err)
+						return errs.New(errs.NotFound, err)
 					default:
 						return errs.Newf(errs.Unauthenticated, "querybyid: userID[%s]: %s", userID, err)
 					}
@@ -125,7 +125,7 @@ func AuthorizeProduct(client *authclient.Client, productBus *productbus.Business
 				if err != nil {
 					switch {
 					case errors.Is(err, productbus.ErrNotFound):
-						return errs.New(errs.Unauthenticated, err)
+						return errs.New(errs.NotFound, err)
 					default:
 						return errs.Newf(errs.Internal, "querybyid: productID[%s]: %s", productID, err)
 					}
@@ -179,7 +179,7 @@ func AuthorizeHome(client *authclient.Client, homeBus *homebus.Business) web.Mid
 				if err != nil {
 					switch {
 					case errors.Is(err, homebus.ErrNotFound):
-						return errs.New(errs.Unauthenticated, err)
+						return errs.New(errs.NotFound, err)
 					default:
 						return errs.Newf(errs.Unauthenticated, "querybyid: homeID[%s]: %s", homeID, err)
 					}


### PR DESCRIPTION
I was misunderstanding the error response I was getting from my cloned service. I just found this in the auth middleware—it seems intentional though. Is it?