### PR TITLE
Delegate.Call error Propagation

### DIFF
--- a/business/sdk/delegate/delegate.go
+++ b/business/sdk/delegate/delegate.go
@@ -4,6 +4,7 @@ package delegate
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ardanlabs/service/foundation/logger"
 )
@@ -56,6 +57,7 @@ func (d *Delegate) Call(ctx context.Context, data Data) error {
 
 				if err := fn(ctx, data); err != nil {
 					d.log.Error(ctx, "delegate call", "err", err)
+					return fmt.Errorf("delegate: %w", err)
 				}
 			}
 		}


### PR DESCRIPTION
I think it's a good idea to propagate callback function errors in `Delegate.Call` method upwards, so that we can rollback the transaction.

I'm also wondering, when inside one of these callback functions, is it a good practice to call into the same Business layer functionalities, or we should make use of functionalities provided in the Storage layer? I can see that `userBus.Authenticate` uses `userBus.QueryByEmail`, but I'm asking this to be sure.

Thanks