### PR TITLE
fix: handle OPTIONS preflight requests for CORS

### DIFF
--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -88,6 +88,12 @@ func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Methods", "POST, PATCH, GET, OPTIONS, PUT, DELETE")
 		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 		w.Header().Set("Access-Control-Max-Age", "86400")
+
+		// Handle pre-flight
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 	}
 
 	// In the following example, max-age is set to 2 years, and is suffixed with


### PR DESCRIPTION
Fix CORS preflight handling for OPTIONS requests

## Problem
Running `make admin-gui-run` fails with CORS errors when the frontend attempts to make API requests with the Authorization header. Browser devtools shows: "Response to preflight request doesn't pass access control check: It does not have HTTP ok status."

## Root Cause
The admin GUI runs on a separate port (localhost:3001 dev / localhost:4173 preview) from the API (localhost:3000), making these cross-origin requests. Browsers automatically send OPTIONS preflight requests before requests with custom headers like Authorization. The current CORS implementation sets headers correctly but doesn't handle OPTIONS requests, causing them to fall through to the router which returns 405 Method Not Allowed instead of the required 200 OK.

## Solution
Added early return in ServeHTTP after setting CORS headers when the request method is OPTIONS, returning 200 OK as required by the CORS spec.

## Testing
```bash
# Before: returns 405
curl -X OPTIONS http://localhost:3000/v1/users -H "Origin: http://localhost:3001"

# After: returns 200
curl -X OPTIONS http://localhost:3000/v1/users -H "Origin: http://localhost:3001"
```

Frontend now works correctly with `make admin-gui-run`.