### PR TITLE
Small cleanup

### DIFF
--- a/api/services/auth/main.go
+++ b/api/services/auth/main.go
@@ -191,7 +191,7 @@ func run(ctx context.Context, log *logger.Logger) error {
 
 	log.Info(ctx, "startup", "status", "initializing tracing support")
 
-	traceProvider, teardown, err := otel.InitTracing(log, otel.Config{
+	traceProvider, teardown, err := otel.InitTracing(otel.Config{
 		ServiceName: cfg.Tempo.ServiceName,
 		Host:        cfg.Tempo.Host,
 		ExcludedRoutes: map[string]struct{}{

--- a/api/services/sales/main.go
+++ b/api/services/sales/main.go
@@ -222,7 +222,7 @@ func run(ctx context.Context, log *logger.Logger) error {
 
 	log.Info(ctx, "startup", "status", "initializing tracing support")
 
-	traceProvider, teardown, err := otel.InitTracing(log, otel.Config{
+	traceProvider, teardown, err := otel.InitTracing(otel.Config{
 		ServiceName: cfg.Tempo.ServiceName,
 		Host:        cfg.Tempo.Host,
 		ExcludedRoutes: map[string]struct{}{

--- a/foundation/otel/otel.go
+++ b/foundation/otel/otel.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ardanlabs/service/foundation/logger"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -32,7 +31,7 @@ type Config struct {
 }
 
 // InitTracing configures open telemetry to be used with the service.
-func InitTracing(log *logger.Logger, cfg Config) (trace.TracerProvider, func(ctx context.Context), error) {
+func InitTracing(cfg Config) (trace.TracerProvider, func(ctx context.Context), error) {
 
 	// WARNING: The current settings are using defaults which may not be
 	// compatible with your project. Please review the documentation for
@@ -54,12 +53,9 @@ func InitTracing(log *logger.Logger, cfg Config) (trace.TracerProvider, func(ctx
 
 	switch cfg.Host {
 	case "":
-		log.Info(context.Background(), "OTEL", "tracer", "NOOP")
 		traceProvider = noop.NewTracerProvider()
 
 	default:
-		log.Info(context.Background(), "OTEL", "tracer", cfg.Host)
-
 		tp := sdktrace.NewTracerProvider(
 			sdktrace.WithSampler(sdktrace.ParentBased(newEndpointExcluder(cfg.ExcludedRoutes, cfg.Probability))),
 			sdktrace.WithBatcher(exporter,

--- a/foundation/worker/worker_test.go
+++ b/foundation/worker/worker_test.go
@@ -24,13 +24,13 @@ func Test_Worker(t *testing.T) {
 		t.Fatalf("Should be able to create a worker with max 4 : %s", err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	for i := 0; i < 4; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-		defer cancel()
 		if _, err := w.Start(ctx, work); err != nil {
 			t.Fatalf("Should be able to execute work : %s", err)
 		}
 	}
+	defer cancel()
 
 	// Wait for all the jobs to finish.
 	for i := 0; i < 4; i++ {
@@ -72,21 +72,21 @@ func Test_CancelWorker(t *testing.T) {
 		t.Fatalf("Should be able to create a worker with max 4 : %s", err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	for i := 0; i < 4; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
 		if _, err := w.Start(ctx, work); err != nil {
 			t.Fatalf("Should be able to execute work : %s", err)
 		}
 	}
+	defer cancel()
 
 	// Wait for all 4 jobs to report they are running.
 	wg.Wait()
 
 	// Give all the jobs 1 second to shut down cleanly.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := w.Shutdown(ctx); err != nil {
+	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel1()
+	if err := w.Shutdown(ctx1); err != nil {
 		t.Fatalf("Should be able to shutdown work cleanly : %s", err)
 	}
 }
@@ -112,15 +112,15 @@ func Test_StopWorker(t *testing.T) {
 		t.Fatalf("Should be able to create a worker with max 4 : %s", err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	for i := 0; i < 4; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
 		work, err := w.Start(ctx, work)
 		if err != nil {
 			t.Fatalf("Should be able to execute work : %s", err)
 		}
 		works = append(works, work)
 	}
+	defer cancel()
 
 	// Wait for all 4 jobs to report they are running.
 	wg.Wait()


### PR DESCRIPTION
This commit removes the depdendency between otel and log foundation packages.

It also removes the usage of defer in for loops, which in certain cases can create resource leaks thus it's better not to use that construct, if possible.