### PR TITLE
Add Tilt and Helm dev workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,15 @@ api/cmd/frontends/admin/.env
 # Folders
 _obj
 _test
+zarf/build/
 
 # Editor files
 .idea/
 *.iml
 *.swp
+.vscode
+CLAUDE.md
+.claude/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Ali Farhadnia <ali.farhadnia.80@gmail.com>
 Amir Hussain Meghdadian <meghdadianah@gmail.com>
 Anaz Ibinu Rasheed <anazibinurasheed@gmail.com>
 Andreas <tullo@users.noreply.github.com>
+Andy Toma <toma.andy98@gmail.com>
 Arash Bina <arash@arash.io>
 Askar Sagyndyk <superwhykz@gmail.com>
 Bardia Kazemi <Bardia.backend@gmail.com>

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,174 @@
+# Ardan Labs Service - Tilt Configuration
+# Local development environment with Kind, Kustomize, and Helm
+#
+# Infrastructure (Database, Observability) deployed via Kustomize
+# Application services (Auth, Sales) deployed via Helm
+#
+# Usage:
+#   tilt up              Start all services
+#   tilt down            Stop all services
+#   tilt logs <service>  View logs for a specific service
+#
+# Services are organized by labels:
+#   - data: Database (Kustomize)
+#   - observability: Grafana, Prometheus, Tempo, Loki, Promtail (Kustomize)
+#   - build: Local binary compilation
+#   - services: Auth, Sales (Helm with hot-reload via live_update)
+
+# Load extensions
+load('ext://restart_process', 'docker_build_with_restart')
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Kubernetes namespace
+k8s_namespace = 'sales-system'
+
+# Allow Kubernetes context (set to your cluster name)
+allow_k8s_contexts('kind-ardan-starter-cluster')
+
+# Tilt settings
+update_settings()
+
+# =============================================================================
+# Infrastructure (using Kustomize)
+# =============================================================================
+# Observability and Database deployed via kustomize for dev
+# Production uses managed services (RDS, Grafana Cloud, etc.)
+# Note: Namespace is created by the kustomize manifests
+
+k8s_yaml(kustomize('./zarf/k8s/dev/database'))
+k8s_resource('database', labels=['data'])
+
+k8s_yaml(kustomize('./zarf/k8s/dev/grafana'), allow_duplicates=True)
+k8s_resource('grafana', labels=['observability'], port_forwards=['3100:3100'])
+
+k8s_yaml(kustomize('./zarf/k8s/dev/prometheus'), allow_duplicates=True)
+k8s_resource('prometheus-deployment', new_name='prometheus', labels=['observability'], port_forwards=['9090:9090'])
+
+k8s_yaml(kustomize('./zarf/k8s/dev/tempo'), allow_duplicates=True)
+k8s_resource('tempo', labels=['observability'])
+
+k8s_yaml(kustomize('./zarf/k8s/dev/loki'), allow_duplicates=True)
+k8s_resource('loki', labels=['observability'])
+
+k8s_yaml(kustomize('./zarf/k8s/dev/promtail'), allow_duplicates=True)
+k8s_resource('promtail', labels=['observability'])
+
+# =============================================================================
+# Auth Service
+# =============================================================================
+
+# Compile binary locally for fast iteration
+local_resource(
+  'auth-compile',
+  'CGO_ENABLED=0 GOOS=linux go build -o ./zarf/build/auth ./api/services/auth',
+  deps=['./api/services/auth', './app', './business', './foundation'],
+  labels=['build'],
+  ignore=['**/*_test.go'],
+)
+
+# Build Docker image with production dockerfile + hot-reload
+docker_build_with_restart(
+  'localhost:5001/ardanlabs/auth',
+  '.',
+  entrypoint=['/service/auth'],
+  dockerfile='./zarf/docker/dockerfile.auth',
+  build_args={'BUILD_TAG': 'develop'},
+  live_update=[
+    sync('./zarf/build/auth', '/service/auth'),
+  ],
+)
+
+# Deploy auth service via Helm
+# Using k8s_yaml + k8s_resource pattern to ensure proper image build dependency
+k8s_yaml(helm(
+  './zarf/helm/charts/auth',
+  namespace=k8s_namespace,
+  values=['./zarf/helm/charts/auth/values-dev.yaml'],
+))
+
+k8s_resource(
+  'auth',
+  labels=['services'],
+  port_forwards=['6000:6000', '6010:6010'],  # HTTP, Debug
+  resource_deps=['auth-compile', 'database'],
+)
+
+# =============================================================================
+# Sales Service
+# =============================================================================
+
+# Compile binaries locally for fast iteration
+local_resource(
+  'sales-compile',
+  'CGO_ENABLED=0 GOOS=linux go build -o ./zarf/build/sales ./api/services/sales && CGO_ENABLED=0 GOOS=linux go build -o ./zarf/build/admin ./api/tooling/admin',
+  deps=['./api/services/sales', './api/tooling/admin', './app', './business', './foundation'],
+  labels=['build'],
+  ignore=['**/*_test.go'],
+)
+
+# Build Docker image with production dockerfile + hot-reload
+docker_build_with_restart(
+  'localhost:5001/ardanlabs/sales',
+  '.',
+  entrypoint=['/service/sales'],
+  dockerfile='./zarf/docker/dockerfile.sales',
+  build_args={'BUILD_TAG': 'develop'},
+  live_update=[
+    sync('./zarf/build/sales', '/service/sales'),
+    sync('./zarf/build/admin', '/service/admin'),
+  ],
+)
+
+# Deploy sales service via Helm
+# Using k8s_yaml + k8s_resource pattern to ensure proper image build dependency
+k8s_yaml(helm(
+  './zarf/helm/charts/sales',
+  namespace=k8s_namespace,
+  values=['./zarf/helm/charts/sales/values-dev.yaml'],
+))
+
+k8s_resource(
+  'sales',
+  labels=['services'],
+  port_forwards=['3000:3000', '3010:3010', '4020:4020'],  # Sales, Debug, Metrics
+  resource_deps=['sales-compile', 'auth', 'database'],
+)
+
+# Run database migrations automatically after sales pod is ready
+# This runs once on startup and when you manually trigger it in Tilt
+local_resource(
+  'sales-migrate',
+  'kubectl wait --for=condition=ready pod -l app=sales -n sales-system --timeout=120s && kubectl exec -n sales-system deployment/sales -c sales -- ./admin migrate-seed',
+  resource_deps=['sales'],
+  labels=['services'],
+)
+
+# =============================================================================
+# Metrics Service
+# =============================================================================
+
+# Compile binary locally for fast iteration
+local_resource(
+  'metrics-compile',
+  'CGO_ENABLED=0 GOOS=linux go build -o ./zarf/build/metrics ./api/services/metrics',
+  deps=['./api/services/metrics', './app', './business', './foundation'],
+  labels=['build'],
+  ignore=['**/*_test.go'],
+)
+
+# Build Docker image with production dockerfile + hot-reload
+docker_build_with_restart(
+  'localhost:5001/ardanlabs/metrics',
+  '.',
+  entrypoint=['/service/metrics'],
+  dockerfile='./zarf/docker/dockerfile.metrics',
+  build_args={'BUILD_TAG': 'develop'},
+  live_update=[
+    sync('./zarf/build/metrics', '/service/metrics'),
+  ],
+)
+
+

--- a/zarf/helm/charts/auth/Chart.yaml
+++ b/zarf/helm/charts/auth/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: auth
+description: Authentication and authorization service
+type: application
+version: 0.1.0
+appVersion: "0.0.1"

--- a/zarf/helm/charts/auth/templates/_helpers.tpl
+++ b/zarf/helm/charts/auth/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Common labels
+*/}}
+{{- define "auth.labels" -}}
+app: auth
+app.kubernetes.io/name: auth
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "auth.selectorLabels" -}}
+app: auth
+app.kubernetes.io/name: auth
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Database environment variables
+*/}}
+{{- define "auth.dbEnvVars" -}}
+- name: AUTH_DB_USER
+  valueFrom:
+    configMapKeyRef:
+      name: auth-config
+      key: db_user
+- name: AUTH_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: auth-secret
+      key: db_password
+- name: AUTH_DB_HOST_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: auth-config
+      key: db_hostport
+- name: AUTH_DB_DISABLE_TLS
+  valueFrom:
+    configMapKeyRef:
+      name: auth-config
+      key: db_disabletls
+{{- end }}
+
+{{/*
+Kubernetes metadata environment variables
+*/}}
+{{- define "auth.k8sEnvVars" -}}
+- name: KUBERNETES_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+- name: KUBERNETES_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: KUBERNETES_POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: KUBERNETES_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+{{- end }}

--- a/zarf/helm/charts/auth/templates/configmap.yaml
+++ b/zarf/helm/charts/auth/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+data:
+  db_hostport: {{ .Values.database.host | quote }}
+  db_user: {{ .Values.database.user | quote }}
+  db_disabletls: {{ .Values.database.disableTls | quote }}

--- a/zarf/helm/charts/auth/templates/deployment.yaml
+++ b/zarf/helm/charts/auth/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "auth.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+  template:
+    metadata:
+      labels:
+        {{- include "auth.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if not .Values.hostNetwork }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      {{- end }}
+      containers:
+        - name: auth
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if not .Values.hostNetwork }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          {{- end }}
+          ports:
+            - name: auth
+              containerPort: {{ .Values.service.ports.http }}
+            - name: auth-debug
+              containerPort: {{ .Values.service.ports.debug }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            {{- include "auth.dbEnvVars" . | nindent 12 }}
+            {{- include "auth.k8sEnvVars" . | nindent 12 }}

--- a/zarf/helm/charts/auth/templates/secret.yaml
+++ b/zarf/helm/charts/auth/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-secret
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  db_password: {{ .Values.secret.password | quote }}
+{{- end }}

--- a/zarf/helm/charts/auth/templates/service.yaml
+++ b/zarf/helm/charts/auth/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "auth.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: auth
+      port: {{ .Values.service.ports.http }}
+      targetPort: auth
+    - name: auth-debug
+      port: {{ .Values.service.ports.debug }}
+      targetPort: auth-debug

--- a/zarf/helm/charts/auth/values-dev.yaml
+++ b/zarf/helm/charts/auth/values-dev.yaml
@@ -1,0 +1,27 @@
+# Development environment overrides
+# Use with: helm install -f values.yaml -f values-dev.yaml
+
+image:
+  repository: localhost:5001/ardanlabs/auth
+  tag: "0.0.1"
+
+replicaCount: 1
+
+strategy:
+  type: Recreate  # Faster for local dev with Tilt
+
+resources:
+  requests:
+    cpu: "100m"
+  limits:
+    cpu: "1000m"
+
+hostNetwork: true  # Required for Kind cluster to access services
+
+database:
+  disableTls: "true"
+
+# Dev: Chart creates secret with hardcoded password
+secret:
+  create: true
+  password: "postgres"

--- a/zarf/helm/charts/auth/values.yaml
+++ b/zarf/helm/charts/auth/values.yaml
@@ -1,0 +1,87 @@
+# Production-ready defaults for Auth service
+# Override these with environment-specific values files
+
+image:
+  repository: registry.example.com/ardanlabs/auth
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+replicaCount: 2
+
+service:
+  type: ClusterIP
+  ports:
+    http: 6000
+    debug: 6010
+
+strategy:
+  type: RollingUpdate
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "256Mi"
+  limits:
+    cpu: "1000m"
+    memory: "512Mi"
+
+hostNetwork: false
+terminationGracePeriodSeconds: 60
+
+readinessProbe:
+  httpGet:
+    path: /v1/readiness
+    port: auth
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 2
+
+livenessProbe:
+  httpGet:
+    path: /v1/liveness
+    port: auth
+  initialDelaySeconds: 2
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 2
+
+namespace: sales-system
+
+database:
+  # For production with managed databases (RDS, Cloud SQL, etc.), configure:
+  # host: "your-db-instance.region.rds.amazonaws.com:5432"
+  # user: "auth_user"
+  # disableTls: "false"
+  host: "database-service:5432"
+  user: "postgres"
+  disableTls: "false"
+
+# Secret management strategy
+# Dev: Chart creates secret with password (see values-dev.yaml)
+# Production: Chart expects secret "auth-secret" to already exist
+#
+# Production example using External Secrets Operator:
+#   apiVersion: external-secrets.io/v1beta1
+#   kind: ExternalSecret
+#   metadata:
+#     name: auth-secret
+#   spec:
+#     refreshInterval: 1h
+#     secretStoreRef:
+#       name: aws-secrets-manager
+#       kind: SecretStore
+#     target:
+#       name: auth-secret
+#     data:
+#       - secretKey: db_password
+#         remoteRef:
+#           key: prod/auth/database
+#           property: password
+#
+# Or manually: kubectl create secret generic auth-secret --from-literal=db_password=xxx
+secret:
+  create: false  # Don't create secret in production
+  password: ""   # Only used if create: true (dev mode)

--- a/zarf/helm/charts/sales/Chart.yaml
+++ b/zarf/helm/charts/sales/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sales
+description: Sales API service with metrics sidecar
+type: application
+version: 0.1.0
+appVersion: "0.0.1"

--- a/zarf/helm/charts/sales/templates/_helpers.tpl
+++ b/zarf/helm/charts/sales/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Common labels
+*/}}
+{{- define "sales.labels" -}}
+app: sales
+app.kubernetes.io/name: sales
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sales.selectorLabels" -}}
+app: sales
+app.kubernetes.io/name: sales
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Database environment variables for Sales service
+*/}}
+{{- define "sales.dbEnvVars" -}}
+- name: SALES_DB_USER
+  valueFrom:
+    configMapKeyRef:
+      name: sales-config
+      key: db_user
+- name: SALES_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: sales-secret
+      key: db_password
+- name: SALES_DB_HOST_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: sales-config
+      key: db_hostport
+- name: SALES_DB_DISABLE_TLS
+  valueFrom:
+    configMapKeyRef:
+      name: sales-config
+      key: db_disabletls
+{{- end -}}
+
+{{/*
+Kubernetes metadata environment variables
+*/}}
+{{- define "sales.k8sEnvVars" -}}
+- name: KUBERNETES_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+- name: KUBERNETES_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: KUBERNETES_POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: KUBERNETES_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+{{- end -}}

--- a/zarf/helm/charts/sales/templates/configmap.yaml
+++ b/zarf/helm/charts/sales/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sales-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sales.labels" . | nindent 4 }}
+data:
+  db_hostport: {{ .Values.database.host | quote }}
+  db_user: {{ .Values.database.user | quote }}
+  db_disabletls: {{ .Values.database.disableTls | quote }}

--- a/zarf/helm/charts/sales/templates/deployment.yaml
+++ b/zarf/helm/charts/sales/templates/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sales
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sales.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "sales.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+  template:
+    metadata:
+      labels:
+        {{- include "sales.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if not .Values.hostNetwork }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      {{- end }}
+
+      {{- if .Values.initContainer.enabled }}
+      initContainers:
+        - name: init-migrate-seed
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{- toYaml .Values.initContainer.command | nindent 12 }}
+          env:
+            {{- include "sales.dbEnvVars" . | nindent 12 }}
+      {{- end }}
+
+      containers:
+        - name: sales
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if not .Values.hostNetwork }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          {{- end }}
+          ports:
+            - name: sales
+              containerPort: {{ .Values.service.ports.http }}
+            - name: sales-debug
+              containerPort: {{ .Values.service.ports.debug }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: GOGC
+              value: {{ .Values.env.GOGC | quote }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            {{- include "sales.dbEnvVars" . | nindent 12 }}
+            {{- include "sales.k8sEnvVars" . | nindent 12 }}
+
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          {{- if not .Values.hostNetwork }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metricsHttp }}
+            - name: metrics-debug
+              containerPort: {{ .Values.service.ports.metricsDebug }}
+            - name: metrics-prom
+              containerPort: {{ .Values.service.ports.metricsPrometheus }}
+          {{- if .Values.metrics.resources }}
+          resources:
+            {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+        {{- end }}

--- a/zarf/helm/charts/sales/templates/secret.yaml
+++ b/zarf/helm/charts/sales/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sales-secret
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sales.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  db_password: {{ .Values.secret.password | quote }}
+{{- end }}

--- a/zarf/helm/charts/sales/templates/service.yaml
+++ b/zarf/helm/charts/sales/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sales-service
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "sales.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "sales.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: sales
+      port: {{ .Values.service.ports.http }}
+      targetPort: sales
+    - name: sales-debug
+      port: {{ .Values.service.ports.debug }}
+      targetPort: sales-debug
+    - name: metrics
+      port: {{ .Values.service.ports.metricsHttp }}
+      targetPort: metrics
+    - name: metrics-debug
+      port: {{ .Values.service.ports.metricsDebug }}
+      targetPort: metrics-debug
+    - name: prometheus
+      port: {{ .Values.service.ports.metricsPrometheus }}
+      targetPort: metrics-prom

--- a/zarf/helm/charts/sales/values-dev.yaml
+++ b/zarf/helm/charts/sales/values-dev.yaml
@@ -1,0 +1,43 @@
+# Development environment overrides
+# Use with: helm install -f values.yaml -f values-dev.yaml
+
+image:
+  repository: localhost:5001/ardanlabs/sales
+  tag: "0.0.1"
+
+replicaCount: 1
+
+strategy:
+  type: Recreate  # Faster for local dev with Tilt
+
+resources:
+  requests:
+    cpu: "250m"
+    memory: "100Mi"
+  limits:
+    cpu: "250m"
+    memory: "100Mi"
+
+metrics:
+  image:
+    repository: localhost:5001/ardanlabs/metrics
+    tag: "0.0.1"
+  resources:
+    requests:
+      cpu: "250m"
+    limits:
+      cpu: "250m"
+
+hostNetwork: true  # Required for Kind cluster to access services
+
+# Disable initContainer in dev - Tilt handles migrations via sales-migrate resource
+initContainer:
+  enabled: false
+
+database:
+  disableTls: "true"
+
+# Dev: Chart creates secret with hardcoded password
+secret:
+  create: true
+  password: "postgres"

--- a/zarf/helm/charts/sales/values.yaml
+++ b/zarf/helm/charts/sales/values.yaml
@@ -1,0 +1,103 @@
+# Production-ready defaults for Sales service
+# Override these with environment-specific values files
+
+# Namespace
+namespace: sales-system
+
+# Image configuration
+image:
+  repository: registry.example.com/ardanlabs/sales
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+# Replica count
+replicaCount: 2
+
+# Service configuration
+service:
+  type: ClusterIP
+  ports:
+    http: 3000
+    debug: 3010
+    metricsHttp: 4000
+    metricsDebug: 4010
+    metricsPrometheus: 4020
+
+# Deployment strategy
+strategy:
+  type: RollingUpdate
+
+# Resource limits
+resources:
+  requests:
+    cpu: "500m"
+    memory: "256Mi"
+  limits:
+    cpu: "1000m"
+    memory: "512Mi"
+
+# Metrics sidecar
+metrics:
+  enabled: true
+  image:
+    repository: registry.example.com/ardanlabs/metrics
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "256Mi"
+
+# Network configuration
+hostNetwork: false
+terminationGracePeriodSeconds: 60
+
+# InitContainer for database migrations
+initContainer:
+  enabled: true
+  command: ["./admin", "migrate-seed"]
+
+# Health checks
+readinessProbe:
+  httpGet:
+    path: /v1/readiness
+    port: sales
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 2
+
+livenessProbe:
+  httpGet:
+    path: /v1/liveness
+    port: sales
+  initialDelaySeconds: 2
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 2
+
+# Environment variables
+env:
+  GOGC: "off"  # Disable GC, use GOMEMLIMIT instead
+
+# Database configuration
+database:
+  # For production with managed databases (RDS, Cloud SQL, etc.), configure:
+  # host: "your-db-instance.region.rds.amazonaws.com:5432"
+  # user: "sales_user"
+  # disableTls: "false"
+  host: "database-service:5432"
+  user: "postgres"
+  disableTls: "false"
+
+# Secret management strategy
+# Dev: Chart creates secret with password (see values-dev.yaml)
+# Production: Chart expects secret "sales-secret" to already exist
+secret:
+  create: false  # Don't create secret in production
+  password: ""   # Only used if create: true (dev mode)

--- a/zarf/k8s/dev/kind-with-registry.sh
+++ b/zarf/k8s/dev/kind-with-registry.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -o errexit
+
+# Desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind-ardan-starter-cluster}"
+
+reg_name='kind-registry'
+reg_port='5001'
+
+# 1. Create registry container unless it already exists
+if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --network bridge --name "${reg_name}" \
+    registry:2
+fi
+
+# 2. Create kind cluster with containerd registry config dir enabled
+# TODO: kind will eventually enable this by default and this patch will
+# be unnecessary.
+#
+# See:
+# https://github.com/kubernetes-sigs/kind/issues/2875
+# https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+cat <<EOF | kind create cluster --name="${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      # Sales-Api
+      - containerPort: 3000
+        hostPort: 3000
+      # Sales-Api debug
+      - containerPort: 3010
+        hostPort: 3010
+      # Metrics
+      - containerPort: 4000
+        hostPort: 4000
+      # Metrics debug
+      - containerPort: 4010
+        hostPort: 4010
+      # Metrics Prometheus
+      - containerPort: 4020
+        hostPort: 4020
+      # Auth
+      - containerPort: 6000
+        hostPort: 6000
+      # Auth debug
+      - containerPort: 6010
+        hostPort: 6010
+      # Grafana
+      - containerPort: 3100
+        hostPort: 3100
+      # Postgres
+      - containerPort: 5432
+        hostPort: 5432
+      # Prometheus
+      - containerPort: 9090
+        hostPort: 9090
+      # Tempo (tracing)
+      - containerPort: 9411
+        hostPort: 9411
+EOF
+
+# 3. Add the registry config to the nodes
+#
+# This is necessary because localhost resolves to loopback addresses that are
+# network-namespace local.
+# In other words: localhost in the container is not localhost on the host.
+#
+# We want a consistent name that works from both ends, so we tell containerd to
+# alias localhost:${reg_port} to the registry container when pulling images
+REGISTRY_DIR="/etc/containerd/certs.d/localhost:${reg_port}"
+for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+  docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+[host."http://${reg_name}:5000"]
+EOF
+done
+
+# 4. Connect the registry to the cluster network if not already connected
+# This allows kind to bootstrap the network but ensures they're on the same network
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  docker network connect "kind" "${reg_name}"
+fi
+
+# 5. Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+echo "Registry is running at localhost:${reg_port}"
+echo "Cluster ${KIND_CLUSTER_NAME} is ready with local registry!"


### PR DESCRIPTION
  Changes are additive and tooling-only:
  - New `Tiltfile` for fast hot-reload; it uses existing Kustomize for infra (db/observability) and Helm only for app services.
  - New Helm charts for `auth` and `sales` under `zarf/helm/charts/*` with dev/prod values.
  - `makefile` adds optional `tilt-*` and `helm-*` targets; existing make targets remain.
  - `dev-up` now uses a new `zarf/k8s/dev/kind-with-registry.sh` helper to create kind + local registry.
  - Minor `.gitignore` additions.

  No changes to application code or existing Kustomize manifests; the original workflow still works.