### PR TITLE
fix(typo): correct parameter naming from ActionDeletedParms to ActionDeletedParams

### DIFF
--- a/business/domain/homebus/event.go
+++ b/business/domain/homebus/event.go
@@ -20,7 +20,7 @@ func (b *Business) registerDelegateFunctions() {
 
 // actionUserDeleted is executed by the user domain indirectly when a user is deleted.
 func (b *Business) actionUserDeleted(ctx context.Context, data delegate.Data) error {
-	var params userbus.ActionDeletedParms
+	var params userbus.ActionDeletedParams
 	err := json.Unmarshal(data.RawParams, &params)
 	if err != nil {
 		return fmt.Errorf("expected an encoded %T: %w", params, err)

--- a/business/domain/productbus/event.go
+++ b/business/domain/productbus/event.go
@@ -20,7 +20,7 @@ func (b *Business) registerDelegateFunctions() {
 
 // actionUserDeleted is executed by the user domain indirectly when a user is deleted.
 func (b *Business) actionUserDeleted(ctx context.Context, data delegate.Data) error {
-	var params userbus.ActionDeletedParms
+	var params userbus.ActionDeletedParams
 	err := json.Unmarshal(data.RawParams, &params)
 	if err != nil {
 		return fmt.Errorf("expected an encoded %T: %w", params, err)

--- a/business/domain/userbus/event.go
+++ b/business/domain/userbus/event.go
@@ -16,24 +16,24 @@ const (
 	ActionDeleted = "deleted"
 )
 
-// ActionDeletedParms represents the parameters for the deleted action.
-type ActionDeletedParms struct {
+// ActionDeletedParams represents the parameters for the deleted action.
+type ActionDeletedParams struct {
 	UserID uuid.UUID
 }
 
 // String returns a string representation of the action parameters.
-func (act *ActionDeletedParms) String() string {
+func (act *ActionDeletedParams) String() string {
 	return fmt.Sprintf("&EventParamsUpdated{UserID:%v}", act.UserID)
 }
 
 // Marshal returns the event parameters encoded as JSON.
-func (act *ActionDeletedParms) Marshal() ([]byte, error) {
+func (act *ActionDeletedParams) Marshal() ([]byte, error) {
 	return json.Marshal(act)
 }
 
 // ActionDeletedData constructs the data for the deleted action.
 func ActionDeletedData(userID uuid.UUID) delegate.Data {
-	params := ActionDeletedParms{
+	params := ActionDeletedParams{
 		UserID: userID,
 	}
 


### PR DESCRIPTION
A typo spotted during **_16.1 Delegate System_** lesson.

Btw. it's a fantastic course! I cannot wait for **Ultimate Go: Software Design with Kubernetes 3.0** 🤞🤞 