### PR TITLE
Rego Import Directive

### DIFF
--- a/app/sdk/auth/rego/authentication.rego
+++ b/app/sdk/auth/rego/authentication.rego
@@ -1,7 +1,5 @@
 package ardan.rego
 
-import rego.v1
-
 default auth := false
 
 auth if {

--- a/app/sdk/auth/rego/authorization.rego
+++ b/app/sdk/auth/rego/authorization.rego
@@ -1,7 +1,5 @@
 package ardan.rego
 
-import rego.v1
-
 role_user := "USER"
 
 role_admin := "ADMIN"


### PR DESCRIPTION
According to [OPA](https://www.openpolicyagent.org/docs/policy-reference/keywords/import#importing-regov1) docs, versions 1.x no longer need to import the necessary keywords using `rego.v1` as they are already present.

I've tried this locally and it works fine.