### PR TITLE
Add new skills to the project

### DIFF
--- a/.agents/skills/branching-logic-flow/SKILL.md
+++ b/.agents/skills/branching-logic-flow/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: branching-logic-flow
+description: Prefer defaulting and naked switches over if/else chains for shallow branching logic in Go. Use when writing or refactoring conditional logic with 1-3 branches.
+---
+
+# Branching Logic Flow
+
+For shallow branching (1-3 cases), prefer **defaulting** or **naked switches** over if/else chains. This reduces
+nesting, avoids duplication, and lowers the cognitive load.
+
+## When to Apply
+
+- Writing new conditional logic with 1-3 branches
+- Refactoring nested if/else blocks
+- Type assertions on `any` / `map[string]any`
+- Any branching where each branch assigns to the same variable
+
+## Rule 1: Default first, override later
+
+Initialize the variable with its default value, then override only in the special case.
+
+❌ Avoid:
+
+```go
+var result map[string]any
+if outer, ok := input["outer"].(map[string]any); ok {
+    if inner, ok := outer["inner"].(map[string]any); ok {
+        result = make(map[string]any, len(inner))
+        maps.Copy(result, inner)
+    } else {
+        result = make(map[string]any)
+    }
+} else {
+    result = make(map[string]any)
+}
+```
+
+✅ Prefer:
+
+```go
+result := make(map[string]any)
+if outer, ok := input["outer"].(map[string]any); ok {
+    if inner, ok := outer["inner"].(map[string]any); ok {
+        result = make(map[string]any, len(inner))
+        maps.Copy(result, inner)
+    }
+}
+```
+
+## Rule 2: Naked switch over if/else if/else ladders
+
+❌ Avoid:
+
+```go
+if a > b {
+    result = a
+} else if a == b {
+    result = a + b
+} else {
+    result = b
+}
+```
+
+✅ Prefer:
+
+```go
+switch {
+case a > b:
+    result = a
+
+case a == b:
+    result = a + b
+
+default:
+    result = b
+}
+```
+
+For simple two-way numeric comparisons, prefer the `min`/`max` built-ins (Go 1.21+):
+
+```go
+result := max(a, b)
+```
+
+## When NOT to Apply
+
+- Default initialization is heavyweight (DB call, large allocation, external API)
+- The "default" case is exceptional and should fail fast with an error
+- Conditions are deeply nested (>3 levels) — extract to a separate function instead
+- Defaulting could mask a bug that should be surfaced explicitly
+
+## Related Modern Go Patterns
+
+- Use `maps.Copy(dst, src)` instead of manual copy loops (destination must be non-nil)
+- Use `cmp.Or(a, b, "default")` to pick the first non-zero value across fallbacks
+- Always use the two-value form `v, ok := x.(T)` for type assertions

--- a/.agents/skills/business-layer-extensions/SKILL.md
+++ b/.agents/skills/business-layer-extensions/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: business-layer-extensions
+description: Use when adding a cross-cutting concern (OTEL tracing, logging, metrics, caching, auth) to a business domain, creating files under business/domain/*/extensions/*, or adding the extension seam (ExtBusiness/Extension) to a *bus package.
+---
+
+# Business Layer Extensions
+
+The business layer layers cross-cutting concerns onto core domain logic with a
+**decorator pattern**: each extension wraps an `ExtBusiness` and delegates to it.
+**Wrap, never modify the core `Business`.** An extension that adds tracing to one
+method must still implement every other method as a plain pass-through.
+
+It comes in three coordinated pieces: the **seam** on the bus (Piece 1), the
+**extension** package itself (Piece 2), and the **wiring** that registers it (Piece 3).
+
+## Checklist
+
+1. **Seam exists?** Confirm the target `<x>bus.go` has `ExtBusiness`, `Extension`,
+   and the reverse-apply loop in `NewBusiness`. If not, add them (piece 1).
+2. **Create** `extensions/<x><concern>/<x><concern>.go` (piece 2).
+3. **Implement EVERY `ExtBusiness` method** — wrap the relevant ones, pass the rest
+   straight through to `ext.bus`. Missing one fails to satisfy the interface and
+   won't compile.
+4. **Wire** into `api/services/*/main.go` in the right order (piece 3).
+
+## Piece 1 — the seam (in `<x>bus/<x>bus.go`)
+
+```go
+// ExtBusiness lists every public method an extension can wrap.
+type ExtBusiness interface {
+	Create(ctx context.Context, input CreateInput) (Model, error)
+	// ... every other public business method
+}
+
+// Extension wraps a new layer of business logic around the existing logic.
+type Extension func(ExtBusiness) ExtBusiness
+
+func NewBusiness(log *logger.Logger, delegate *delegate.Delegate, storer Storer, extensions ...Extension) ExtBusiness {
+	b := ExtBusiness(&Business{ /* ... */ })
+
+	for i := len(extensions) - 1; i >= 0; i-- { // reverse: first-listed = outermost
+		if ext := extensions[i]; ext != nil {
+			b = ext(b)
+		}
+	}
+	return b
+}
+```
+
+## Piece 2 — the extension (`extensions/<x><concern>/<x><concern>.go`)
+
+Package name is `<x><concern>` (e.g. `widgetotel`, `widgetlog`). Struct holds the
+wrapped bus plus any deps; `NewExtension` returns the closure.
+
+```go
+// Package widgetotel provides an extension for WidgetBus to add OTEL related
+// code on top of it without changing the existing logic.
+package widgetotel
+
+type Extension struct {
+	bus widgetbus.ExtBusiness
+}
+
+func NewExtension() widgetbus.Extension {
+	return func(bus widgetbus.ExtBusiness) widgetbus.ExtBusiness {
+		return &Extension{bus: bus}
+	}
+}
+
+// Wrapped method — adds the concern, then delegates.
+func (ext *Extension) Create(ctx context.Context, input widgetbus.CreateWidgetInput) (widgetbus.Widget, error) {
+	ctx, span := otel.AddSpan(ctx, "business.widgetbus.create")
+	defer span.End()
+
+	w, err := ext.bus.Create(ctx, input)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return w, err
+	}
+	span.SetStatus(codes.Ok, "")
+	return w, nil
+}
+
+// Pass-through method — NOT relevant to this concern, but REQUIRED for the interface.
+func (ext *Extension) Delete(ctx context.Context, w widgetbus.Widget) error {
+	return ext.bus.Delete(ctx, w)
+}
+```
+
+### Metrics variant
+
+For a Prometheus metrics extension, follow the repo house style: a package-level
+singleton built in `init()` with `promauto`, `_total` counter naming, and a `status`
+label. Record after delegating, then return the original result.
+
+```go
+var metrics = struct {
+	created *prometheus.CounterVec
+}{
+	created: promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "widgetbus_created_total",
+		Help: "The total number of widget create operations.",
+	}, []string{"status"}),
+}
+
+func status(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "success"
+}
+
+func (ext *Extension) Create(ctx context.Context, input widgetbus.CreateWidgetInput) (widgetbus.Widget, error) {
+	w, err := ext.bus.Create(ctx, input)
+	metrics.created.WithLabelValues(status(err)).Inc()
+	return w, err
+}
+```
+
+## Piece 3 — wiring (`api/services/*/main.go`)
+
+Construct each extension, then pass them as the trailing variadic args to `NewBusiness`
+in outermost-first order:
+
+```go
+widgetOtelExt := widgetotel.NewExtension() // first = outermost wrapper
+widgetLogExt := widgetlog.NewExtension(log)
+widgetBus := widgetbus.NewBusiness(log, delegate, widgetStorage, widgetOtelExt, widgetLogExt)
+```
+
+**Order matters.** `NewBusiness` applies extensions in reverse, so the first one passed is
+the outermost layer (runs first on the way in, last on the way out). The repo convention
+is OTEL first (outermost span), then logging/metrics inside it.
+
+## Common mistakes
+
+- **Forgetting a pass-through method** → interface not satisfied, compile error. List
+  every `ExtBusiness` method first, then fill them in.
+- **Guessing the wrap order** — first in the slice is outermost, not innermost.
+- **Modifying core `Business`** to add the concern instead of wrapping it. The whole
+  point is to leave core logic untouched.
+- These extensions forward already-typed Business values, so layer-boundary converters
+  usually don't apply — but if you touch primitives or DB rows, follow
+  `layered-architecture-types`.
+
+Use `use-modern-go` for syntax.

--- a/.agents/skills/layered-architecture-types/SKILL.md
+++ b/.agents/skills/layered-architecture-types/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: layered-architecture-types
+description: Enforce primitive-at-edges / strong-types-in-Business layering and the toBus/fromBusResponse/toDB converter pattern. Use when writing, editing, or auditing Go files under app/*, business/domain/*, or .../stores/*db.
+---
+
+# Layered Architecture Types
+
+Data crosses three layers. **Primitive types live at the edges (API JSON and DB
+rows); strong types from `business/types` live only in the Business layer.** Every
+crossing goes through a named conversion function — never assign across a boundary
+directly, and never let a strong type appear in an API request/response struct or a
+DB row struct.
+
+```
+API (app/*)            Business (business/domain/*)        Storage (.../stores/*db)
+primitive types  ──►   strong types (business/types/*)    ──►   native DB types
+request struct    toBus<Type>          model type        toDB<Type>     db<Type> row
+response struct   ◄── fromBus<Type>Response   ◄── toBus<Type>  ◄──
+                      (App layer)                  (Storage layer)
+```
+
+## When to Apply
+
+- Writing or editing API request/response types under `app/*`
+- Writing or editing Business model types under `business/domain/*/model.go`
+- Writing or editing DB row structs and store code under `.../stores/*db`
+- Auditing any of the above for layering conformance
+
+## User controls the types (MUST)
+
+The user owns every type choice this skill touches — field types, DB column
+representations, converter signatures, and any wrapper types.
+
+- Before committing changes or writing a final review summary, state the concrete
+  types you intend to use at each affected boundary (request/response field, DB row
+  field, converter return) and get the user's explicit confirmation. Do not finalize
+  on an assumed default.
+- **Suggest existing types first.** When proposing a type, prefer one that already
+  exists: a strong type from one of the `business/types/*` subpackages for the
+  Business layer, or a type already defined locally in the package(s) you are
+  editing. Only propose a brand-new type when nothing existing fits, and say why.
+- Call out anything noteworthy for them to decide: pointer vs value, `sql.Null*` vs
+  wrapper, `json.RawMessage` vs a typed struct, and how NULL/empty is represented.
+- If the user picks a type that diverges from the patterns here, follow their
+  choice and adapt the converters to it.
+
+## Type boundaries (MUST)
+
+- **API request/response structs** (`app/*`): primitives only — `string`, `int`,
+  `bool`, `json.RawMessage`, `time.Time`, and slices/structs of these. Never a
+  `business/types/*` strong type.
+- **Business model types** (`business/domain/*/model.go`): strong types for
+  IDs, enums, and classifications.
+- **DB row structs** (`.../stores/*db`): native/SQL types only — `string`,
+  `sql.Null*`, `json.RawMessage`, `time.Time`. Never a `business/types` strong
+  type, **including validated enums — store them as `string`.**
+
+## Package imports (MUST)
+
+- **No cross-domain Business imports.** A Business domain package
+  (`business/domain/<x>bus`) must not import another Business domain package
+  (`.../<y>bus`). Compose across domains in the App layer, not by reaching sideways
+  in Business.
+- **No cross-domain App imports.** An App domain package (`app/domain/<x>app`)
+  must not import another App domain package (`.../<y>app`).
+- **An App package may import several Business domain packages.** This is the
+  intended place to combine domains — e.g. an app handler importing both
+  `<x>bus` and `<y>bus` to assemble a response is allowed and expected.
+- `business/types/*` and `foundation/*` are shared leaf packages: any layer may
+  import them, and they must not import App or Business domain packages.
+
+## Foundation types are wrapped, not used directly (MUST)
+
+Foundation types (`foundation/*`) must not appear directly in `business/types/*`
+aggregate types or in Business domain models. Define a `business/types` wrapper
+type and convert via `toFoundation<T>` / `fromFoundation<T>` at the
+foundation-client boundary. A wrapper may store the foundation value in an
+unexported field and delegate (un)marshaling to it; the public type the aggregate
+references is the wrapper, never the foundation type.
+
+## Pointer types (avoid)
+
+Prefer non-pointer types at every layer. Reach for a pointer only when there is no
+non-pointer way to express the requirement, and say why in the proposal.
+
+- For nullable columns, prefer value types that already model absence: `sql.Null*`
+  for scalars, and for nullable `JSONB` a small `sql.Scanner`/`driver.Valuer`
+  wrapper around `json.RawMessage` that scans NULL into the empty value — not
+  `*json.RawMessage`, and not a `COALESCE(col, CAST('null' AS jsonb))` patch that
+  silently turns NULL into the JSON scalar `null` and defeats `omitempty`.
+- Before reaching for a wrapper or a pointer, consider whether the data's shape can
+  change so the situation cannot arise at all — and offer that to the user as an
+  alternative, since it is their call:
+  - **Storage:** a `NOT NULL DEFAULT '{}'::jsonb` (or `DEFAULT 'null'::jsonb`) column
+    never yields a NULL to scan, removing the need for any special handling. This is
+    a schema/migration change.
+  - **App-layer incoming request:** if a request field's absence is the only reason a
+    pointer/wrapper is being considered, prefer making the field required (validate
+    it in `toBus<Type>`) or defaulting it to a zero value, so the field stays a plain
+    primitive instead of `*T`.
+  - Note the trade-off either way: a NOT NULL default or a forced default collapses
+    "unset" and "empty" into one value, which may or may not be acceptable for the
+    field.
+- Do not introduce a pointer field, parameter, or return value to signal
+  optionality when a zero value, `sql.Null*`, or an explicit "is set" flag does the
+  job.
+- If a pointer genuinely is the only option, surface that to the user as part of
+  the type confirmation below before writing it.
+
+## Converter functions (MUST exist per type, both directions)
+
+| Direction          | Layer pair         | Name                    | Returns |
+|--------------------|--------------------|-------------------------|---------|
+| primitive → strong | App → Business     | `toBus<Type>`           | `(busInput, error)` — parse + validate, accumulate `errs.FieldErrors` |
+| strong → primitive | Business → App     | `fromBus<Type>Response` | response struct — convert each strong field with `.String()` etc. |
+| strong → native    | Business → Storage | `toDB<Type>`            | db row struct |
+| native → strong    | Storage → Business | `toBus<Type>`           | `(busType, error)` — parse via the relevant `business/types/*` `Parse*` |
+
+Rules for these functions:
+
+- **All parsing and validation happens in the App-layer `toBus<Type>`.** Parse each
+  primitive into its strong type; on failure `fieldErrors.Add(field, err)` and
+  return `errs.FieldErrors`. The request struct carries only strings — do not put
+  strong types in it and do not validate strong types there.
+- `fromBus<Type>Response` converts explicitly (`id.String()`, `cls.String()`).
+  Never rely on a strong type's `MarshalJSON` to hide a leak — the field type in
+  the response struct must already be primitive.
+- Storage `toBus<Type>` validates native values back into strong types and returns
+  an error (e.g. `<subpkg>.Parse<Type>(row.ID)`); `toDB<Type>` calls `.String()` to
+  flatten strong types into natives.
+- One converter pair per persisted type, per CRUD op that needs it (Create / Get /
+  List / Update / Delete).
+
+## Constructor naming: Parse / MustParse only (MUST)
+
+Strong types in `business/types/*` (IDs, enums, classifications, names, sizes) MUST
+expose their public constructors as `Parse<Type>` and `MustParse<Type>` — never
+`New<Type>` or `MustNew<Type>`.
+
+- `Parse<Type>(s string) (<Type>, error)` — parses + validates a primitive into the
+  strong type, returning an error on invalid input. This is what converters call
+  (e.g. `<subpkg>.Parse<Type>`).
+- `MustParse<Type>(s string) <Type>` — panics on invalid input. Reserve for tests
+  and package-level vars with known-good constants, never for request-derived data.
+- **Reject `New*` / `MustNew*` for these types.** If you find them, rename to
+  `Parse*` / `MustParse*` and update call sites. This applies to every public
+  constructor of a strong type, including typed (non-string) variants — e.g.
+  `New<Type>FromUUID(uuid.UUID)` becomes `Parse<Type>FromUUID(uuid.UUID)`. Only keep a
+  `New*` form when the user gives a concrete, convincing reason; when in doubt, ask
+  the user rather than introducing or retaining a `New*` constructor.
+
+## Example — App layer (both directions)
+
+```go
+// Request carries only primitives.
+type CreateWidgetRequest struct {
+	Name    string `json:"name"`
+	OwnerID string `json:"owner_id"` // NOT a strong OwnerID type
+}
+
+// toBus parses + validates here.
+func toBusCreateWidget(req CreateWidgetRequest) (widgetbus.CreateWidgetInput, error) {
+	var fieldErrors errs.FieldErrors
+
+	ownerID, err := types.ParseOwnerID(req.OwnerID)
+	if err != nil {
+		fieldErrors.Add("owner_id", err)
+	}
+
+	if len(fieldErrors) > 0 {
+		return widgetbus.CreateWidgetInput{}, fieldErrors
+	}
+
+	return widgetbus.CreateWidgetInput{
+		Name:    strings.TrimSpace(req.Name),
+		OwnerID: ownerID,
+	}, nil
+}
+
+// fromBus converts strong -> primitive explicitly.
+func fromBusCreateWidgetResponse(w widgetbus.Widget) CreateWidgetResponse {
+	return CreateWidgetResponse{
+		ID:      w.ID.String(),
+		OwnerID: w.OwnerID.String(),
+		Name:    w.Name,
+	}
+}
+```
+
+## Example — Storage layer (both directions)
+
+```go
+type dbWidget struct {
+	ID      string `db:"id"`       // native, not a strong WidgetID type
+	OwnerID string `db:"owner_id"`
+}
+
+func toDBWidget(w widgetbus.Widget) dbWidget {
+	return dbWidget{
+		ID:      w.ID.String(),
+		OwnerID: w.OwnerID.String(),
+	}
+}
+
+func toBusWidget(row dbWidget) (widgetbus.Widget, error) {
+	id, err := types.ParseWidgetID(row.ID)
+	if err != nil {
+		return widgetbus.Widget{}, fmt.Errorf("parse widget id: %w", err)
+	}
+	// ... parse remaining native values into strong types ...
+	return widgetbus.Widget{ID: id /* ... */}, nil
+}
+```
+
+Names above are illustrative — do not confuse them with real codebase symbols.
+
+## Conformance checklist
+
+Before finishing work on any layer, confirm:
+
+- [ ] No `business/types` strong type appears in an API request/response struct.
+- [ ] No `business/types` strong type appears in a DB row struct (validated enums
+      stored as `string`).
+- [ ] Each crossing has its named function: `toBus<Type>`, `fromBus<Type>Response`,
+      `toDB<Type>`, and storage `toBus<Type>`.
+- [ ] App-layer `toBus<Type>` parses + validates and returns `errs.FieldErrors`.
+- [ ] `fromBus<Type>Response` converts every strong field explicitly (no reliance
+      on `MarshalJSON`).
+- [ ] Storage `toBus<Type>` returns an error and parses natives into strong types.
+- [ ] Strong-type constructors are named `Parse<Type>` / `MustParse<Type>`, not
+      `New*` / `MustNew*` (unless the user gave a concrete reason to keep a `New*`).
+- [ ] No pointer type was introduced where a value type, `sql.Null*`, or "is set"
+      flag would do.
+- [ ] Proposed types reused an existing `business/types/*` or local package type
+      where one fit, rather than defining a new type.
+- [ ] No Business domain package imports another Business domain package, and no App
+      domain package imports another App domain package.
+- [ ] No `foundation/*` type appears directly in a `business/types` aggregate or a
+      Business domain model; each is wrapped with `toFoundation`/`fromFoundation`
+      converters.
+- [ ] The user confirmed the concrete types at each affected boundary before this
+      work was finalized.
+
+## When NOT to Apply
+
+- Internal helpers and code that never crosses a layer boundary.
+- Foundation packages (`foundation/*`) and `business/types/*` themselves.
+- Pure intra-package refactors that don't move data between App, Business, or
+  Storage.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: review-pr
+description: "Service Diffguard: read-only PR review lenses for correctness, error visibility, comment truthfulness, test coverage, type/contract boundaries, and simplification across every language in this repo (Go, Vue/JS/SCSS, Rego, protobuf, SQL, Helm/YAML, shell). Use for PR review, pre-commit review, unstaged-diff review, or a targeted review of one of those aspects."
+---
+
+# Service Diffguard
+
+Service Diffguard reviews a diff with six focused **lenses**. Each lens runs as
+a read-only Amp Task subagent, inspects the requested change, and returns
+**findings** graded on one shared scale. Lenses advise only — they never edit,
+stage, or commit code, never disable tests, and never bypass a failing check to
+make it pass.
+
+Default scope is the **unstaged `git diff`** unless the caller names specific
+files, a branch, a commit range, or an existing PR.
+
+## Gate scale
+
+Every finding carries a Gate. The run's overall Gate is the highest any lens
+returns.
+
+| Gate   | Name    | Meaning                                                                                  | Action                                               |
+|--------|---------|------------------------------------------------------------------------------------------|------------------------------------------------------|
+| **G4** | Stop    | Likely correctness, security, data-integrity, compile, boundary, or reliability failure. | Block merge until fixed.                             |
+| **G3** | Repair  | Likely user-visible bug, operational blind spot, real test gap, or misleading contract.  | Fix before the PR is ready.                          |
+| **G2** | Tighten | Locally safe but leaves avoidable risk, ambiguity, weak design, or brittleness.          | Address if reasonably scoped; otherwise acknowledge. |
+| **G1** | Polish  | Low-risk clarity, naming, comment, or small test refinement.                             | Optional; batch, don't spam.                         |
+| **G0** | Clear   | No issue, or a positive observation.                                                     | None.                                                |
+
+Every **G2 or higher** finding must include: `file:line`, **Proof** (evidence from
+the diff), why it matters, a **Patch direction** (smallest safe fix), and how to
+verify. Weak or speculative observations go under **Open checks**, not as a
+finding. Cap **G1** items at five per lens unless exhaustive polish is requested.
+
+## Lens catalog
+
+| Lens                   | Focus                                  | Reference prompt                  |
+|------------------------|----------------------------------------|-----------------------------------|
+| **Service Steward**    | general code correctness & conventions | `reference/service-steward.md`    |
+| **Error Tripwire**     | failure-path visibility                | `reference/error-tripwire.md`     |
+| **Doc Drift Check**    | comment truthfulness                   | `reference/doc-drift-check.md`    |
+| **Harness Map**        | behavior-to-test mapping               | `reference/harness-map.md`        |
+| **Boundary Keeper**    | type & contract design across layers   | `reference/boundary-keeper.md`    |
+| **Straight-Line Pass** | behavior-preserving simplification     | `reference/straight-line-pass.md` |
+
+## Languages in this repo
+
+Diffguard reviews a changed file in whatever language it is written in. Each lens
+applies its concept (correctness, failure visibility, comment truth, test
+coverage, contract design, simplification) through the idioms of that language —
+Go is the primary codebase, not the only one.
+
+| Area            | Where                                                      | Lens focus for this language                                                                                                                |
+|-----------------|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| Go services     | `app/**`, `business/**`, `foundation/**`, `api/**` (`.go`) | Full Go review; the layered type rules and Go skills apply here.                                                                            |
+| Admin frontend  | `api/frontends/admin/src` (`.vue`, `.js`, `.scss`)         | Vue SFC structure, component `props`/`emits` contracts, reactivity, async/`fetch` error handling, accessibility, leaked watchers/listeners. |
+| Auth policies   | `app/sdk/auth/rego` (`.rego`)                              | OPA/Rego rules: default-deny posture, `input` shape assumptions, unintended allows.                                                         |
+| gRPC contracts  | `app/domain/grpcauthapp` (`.proto`)                        | Field-number stability, backward/forward compatibility, breaking changes.                                                                   |
+| Database        | `business/sdk/migrate/sql` (`.sql`)                        | Migration reversibility/idempotency, indexing, locking, destructive changes, seed correctness.                                              |
+| Deploy / config | `zarf/**` (`.yaml`, `.tpl`), `*.conf`                      | Helm/k8s manifests: resource limits, secrets handling, probes, value templating.                                                            |
+| Scripts         | `*.sh`                                                     | Shell safety: `set -euo pipefail`, quoting, exit-code handling.                                                                             |
+
+## Repo-local authority
+
+All lenses treat **AGENTS.md** (and any nested AGENTS.md) as authoritative.
+
+Apply these repo skills **only to `.go` files**, where relevant:
+
+- `use-modern-go` — Go implementation style.
+- `layered-architecture-types` — App ↔ Business ↔ Storage: primitives at the
+  edges, strong types in Business, named converters only.
+- `business-layer-extensions` — the `ExtBusiness` / `Extension` decorator seam.
+- `branching-logic-flow` — defaulting and shallow control flow.
+
+`validate-pr-title` applies whenever the PR title is in scope, regardless of
+language.
+
+## Diff intake
+
+1. Resolve scope from the caller.
+2. With no explicit scope, inspect unstaged changes:
+   - `git status --short`
+   - `git diff --name-only`
+   - `git diff`
+   - For a branch/PR: `git diff --name-only <base>...HEAD`, or `gh pr diff`.
+3. Build a short change inventory: which languages/areas changed (see *Languages
+   in this repo*); production vs test files; App/Business/Storage files; comments
+   or doc strings; error/failure handling; new or modified types, interfaces,
+   converters, component contracts, proto messages, or SQL schema; PR title if a
+   PR is in scope.
+
+## Lens routing
+
+Route by what changed unless the caller asks for "full", "all", or "PR-ready".
+
+- **Always** (any production code changed, any language): Service Steward.
+- **Production code or tests changed, or coverage asked:** Harness Map.
+- **Diff touches any failure path** — Go `err`/`errors.Is/As`/wrapping/`defer`/
+  `recover`/context, JS `try/catch`/promises/`await`/`fetch`, SQL transactions,
+  Rego allow/deny logic, or shell exit codes; plus logging and fallback/default
+  behavior: Error Tripwire.
+- **Any contract or shape changed** — Go structs/interfaces/constructors/
+  converters/Business strong types/DB rows/stores, Vue `props`/`emits`, proto
+  messages, or SQL schema: Boundary Keeper.
+- **Comments, doc strings (Go doc, JSDoc), examples, README snippets, or
+  TODO/FIXME changed:** Doc Drift Check.
+- **Polish pass:** Straight-Line Pass — run in a second wave after G4/G3 findings are
+  resolved, or in the first wave only when simplification is explicitly requested.
+
+## Execution
+
+Run lenses as Task subagents. Because they are read-only, **parallel is safe** and
+preferred for a broad PR sweep; prefer **sequential** when scope is ambiguous, the
+diff is very large, or only one concern was requested.
+
+Default is a two-wave plan:
+
+- **Wave 1 (risk):** Service Steward, Harness Map, plus Error Tripwire, Boundary
+  Keeper, and Doc Drift Check where applicable.
+- **Wave 2 (polish, optional):** Straight-Line Pass, after high-risk findings are
+  addressed or when requested.
+
+Launch each lens with a prompt of this shape:
+
+```text
+Use `.agents/skills/review-pr/reference/<lens>.md` as your review instructions.
+
+Scope: <exact scope>
+Diff source: <unstaged git diff | PR diff | branch range | file list>
+Languages in scope: <e.g. Go; Vue/JS; Rego; proto; SQL; Helm/YAML; shell>
+Repo context: polyglot monorepo (Go primary). Follow AGENTS.md; apply Go skills to .go files only.
+Mode: advisory/read-only — do not modify files.
+
+Return a Gate report only, using the G0-G4 scale.
+```
+
+## Aggregation
+
+Merge lens reports into one Diffguard report. Deduplicate overlapping findings by
+failure mode and location; on disagreement keep the higher Gate.
+
+```markdown
+# Service Diffguard Report
+
+Scope: <scope reviewed>
+Overall Gate: G[0-4] — <Clear/Polish/Tighten/Repair/Stop>
+
+## Run matrix
+| Lens               | Result        | Notes |
+|--------------------|---------------|-------|
+| Service Steward    | Gx            | ...   |
+| Error Tripwire     | Gx / skipped  | ...   |
+| Doc Drift Check    | Gx / skipped  | ...   |
+| Harness Map        | Gx / skipped  | ...   |
+| Boundary Keeper    | Gx / skipped  | ...   |
+| Straight-Line Pass | Gx / deferred | ...   |
+
+## Fix queue
+### G4 Stop
+- [lens] <title> — `file.go:line`
+  - Proof:
+  - Patch direction:
+  - Verify:
+### G3 Repair
+### G2 Tighten
+### G1 Polish
+
+## Clear signals
+- <What looks solid and why.>
+
+## Open checks
+- <Anything not reviewed, unavailable, or needing human confirmation.>
+
+## Suggested verification
+- Go: `make test-only`, or `go test ./path/...` for a single package.
+- Frontend: the project's JS test/lint/build scripts in `api/frontends/admin`.
+- SQL/Rego/proto: the relevant migration, policy, or codegen check for that area.
+- Re-run affected lenses after fixes.
+```

--- a/.agents/skills/review-pr/reference/boundary-keeper.md
+++ b/.agents/skills/review-pr/reference/boundary-keeper.md
@@ -1,0 +1,100 @@
+# Boundary Keeper (type & contract design)
+
+The type, contract, and boundary lens. It reviews new or modified data shapes —
+Go types/interfaces/converters, plus other languages' contracts — asking whether
+the design makes valid states easy, invalid states hard, and crossings explicit.
+
+- **Default scope:** unstaged `git diff`, unless the caller gives another scope.
+- **Mode:** advisory / read-only. Never modify, stage, or commit code.
+
+## Charter
+
+You are the Boundary Keeper. Your primary duty is the Go monorepo's strict
+type-boundary rule — guard it: API JSON request/response structs use primitives;
+DB row structs use primitive / native DB-facing shapes; the Business layer uses
+strong types from `business/types/*`; every crossing goes through a named
+converter; nothing is assigned directly across the App ↔ Business ↔ Storage
+boundaries. Apply the `layered-architecture-types` skill whenever the diff touches
+`app/*`, `business/domain/*`, or store files.
+
+Beyond Go, you also guard the repo's other contracts: keep them explicit,
+compatible, and hard to misuse.
+
+## Language lens
+
+- **Go** (primary): exported vs unexported fields; constructors and their
+  validation; zero-value semantics; pointer vs value receivers; mutation methods
+  that must preserve invariants; small consumer-owned interfaces; unnecessary
+  interfaces or generics; aliases that erase domain meaning; converter names and
+  validation behavior; and the error shape returned for invalid construction.
+- **Vue/JS**: component `props`/`emits` contracts — required vs optional, types/
+  validators, default values, and event payload shapes; props treated as
+  immutable; no leaking of internal state shape.
+- **proto**: field-number stability, reserved fields, optional vs required
+  semantics, and backward/forward compatibility of every message change.
+- **SQL**: column types, nullability, constraints, and keys that encode the same
+  invariants the Go strong types expect; no schema that lets invalid rows exist.
+
+## Patrol route
+
+**1. Type ledger.** For each changed type, capture its package/layer, exported
+surface, valid-state rules, construction path, mutation path, any
+serialization/DB/API crossing, and its relationship to Business strong types.
+
+**2. Invariant review.** Can invalid values be created directly? Are invariants
+checked once at the boundary rather than scattered? Are mutation methods guarded?
+Does the type communicate domain meaning? Is the design simpler than the bug it
+prevents?
+
+**3. Boundary review.** Primitive leakage into Business logic; strong types leaking
+into edge (API/DB) structs; a missing `toBus<Type>`, `fromBus<Type>Response`, or
+`toDB<Type>`; direct assignment across layers; validation split across locations
+with no clear owner.
+
+## Gate mapping
+
+- **G4 Stop** — a layer-boundary violation, a constructible invalid Business state,
+  a converter bypass, or a design that can corrupt persisted/domain data.
+- **G3 Repair** — exported fields or a missing constructor allow meaningful
+  invariant breakage.
+- **G2 Tighten** — invariants exist but are unclear, scattered, or weakly named.
+- **G1 Polish** — naming/doc refinements around type intent.
+- **G0 Clear** — the type is simple, scoped, and enforces the right rules.
+
+## Output template
+
+```markdown
+# Boundary Keeper Report
+
+Scope: <scope>
+Overall Gate: Gx — <name>
+
+## Type ledger
+| Type | Layer | Purpose | Posture |
+| --- | --- | --- | --- |
+| `<TypeName>` | App/Business/Storage | <purpose> | Gx |
+
+## Per-type review
+### `<TypeName>`
+- Valid-state rules: <rules>
+- Construction path: <constructor / converter>
+- Boundary crossings: <toBus / fromBusResponse / toDB / ...>
+
+#### Gate findings
+##### Gx — <short title>
+- Where: `path/file.go:line`
+- Proof: <specific type or boundary issue>
+- Why it matters: <invalid state / layer leak / maintenance risk>
+- Patch direction: <constructor / converter / field visibility / validation change>
+- Verify: <test or review step>
+
+## Clear signals
+- <Strong type decisions worth keeping.>
+
+## Open checks
+- <Domain-invariant questions.>
+```
+
+Favor compile-time guarantees over runtime checks, weigh the cost of every
+suggestion, and remember a simpler type with fewer guarantees often beats a complex
+one that does too much. Advise only — never modify code.

--- a/.agents/skills/review-pr/reference/doc-drift-check.md
+++ b/.agents/skills/review-pr/reference/doc-drift-check.md
@@ -1,0 +1,88 @@
+# Doc Drift Check (comment truthfulness)
+
+The comment-truthfulness lens. It accepts a comment only when it helps a future
+maintainer understand behavior, intent, constraints, or domain rules the code does
+not already make obvious — and flags **doc drift**: comments that disagree with the
+implementation, promise behavior the code lacks, or just restate the obvious.
+
+- **Default scope:** unstaged `git diff`, unless the caller gives another scope.
+- **Mode:** advisory / read-only. Never modify, stage, or commit code.
+
+## Charter
+
+You are Doc Drift Check. Read each changed comment as a contract and confirm the
+code honors it. Hunt for comments that contradict the code, omit important caveats
+on exported APIs, restate obvious code, preserve outdated assumptions, or freeze
+temporary context as if it were permanent design.
+
+## Language lens
+
+The principles are language-agnostic; check comments and doc strings wherever the
+diff has them.
+
+- **Go** (primary): exported identifiers carry useful Go doc where package style
+  requires it, doc comments begin with the identifier name where that convention
+  applies, and comments around converters / Business strong types match the layer
+  rules.
+- **Vue/JS**: JSDoc and component-level comments match actual `props`/`emits`,
+  events, and behavior.
+- **SQL / Rego / proto / Helm**: header and inline comments describe what the
+  migration, policy, message, or template actually does.
+- Across all languages: comments describe observable behavior, errors, side
+  effects, ordering, and invariants — not line-by-line narration; example snippets
+  still hold against the current API; and TODO/FIXME notes are still true and
+  actionable.
+
+## Patrol route
+
+**1. Build a claim ledger.** For each changed comment, list the claims it makes:
+inputs, outputs, errors, side effects, ordering, concurrency, invariants, layer
+ownership, operational behavior.
+
+**2. Match claims to code.** Check every claim against the changed implementation
+and the nearby unchanged context it describes.
+
+**3. Decide: keep, rewrite, or remove.** Keep comments that capture durable intent;
+rewrite stale or incomplete claims; remove comments that narrate obvious code.
+
+## Gate mapping
+
+- **G4 Stop** — a misleading comment could drive unsafe use, a data/security
+  mistake, or a wrong operational action.
+- **G3 Repair** — an exported-API doc or domain comment materially contradicts the
+  behavior.
+- **G2 Tighten** — non-obvious behavior or an invariant lacks the context a
+  maintainer needs.
+- **G1 Polish** — redundant, wordy, or style-level comment cleanup.
+- **G0 Clear** — comments are accurate and useful.
+
+## Output template
+
+```markdown
+# Doc Drift Check Report
+
+Scope: <scope>
+Overall Gate: Gx — <name>
+
+## Comment inventory
+- Changed comments reviewed: <count or list>
+- Exported API docs reviewed: <count or list>
+
+## Gate findings
+### Gx — <short title>
+- Where: `path/file.go:line`
+- Current claim: <what the comment says>
+- Proof: <what the code actually does>
+- Why it matters: <maintenance / API / domain risk>
+- Patch direction: <remove / rewrite / add context>
+- Suggested wording:
+  > <replacement comment, if useful>
+
+## Clear signals
+- <Comments that are accurate and worth keeping.>
+
+## Open checks
+- <Claims needing product or domain confirmation.>
+```
+
+You analyze and advise only — propose wording, never edit the code yourself.

--- a/.agents/skills/review-pr/reference/error-tripwire.md
+++ b/.agents/skills/review-pr/reference/error-tripwire.md
@@ -1,0 +1,95 @@
+# Error Tripwire (failure-path visibility)
+
+The failure-visibility lens. It walks every changed failure path and confirms that
+when something goes wrong, the caller, operator, or test can actually see it —
+rather than the code returning a zero value, logging-and-continuing, or reporting
+success after a partial failure.
+
+- **Default scope:** unstaged `git diff`, unless the caller gives another scope.
+- **Mode:** advisory / read-only. Never modify, stage, or commit code.
+
+## Charter
+
+You are the Error Tripwire. Trace each changed failure path to its end and decide:
+if this operation fails, who finds out, and is that enough to debug it later?
+"Failure visibility" looks different per language, but the question is the same.
+
+## Failure idioms by language
+
+- **Go** (primary): errors are checked, wrapped with context (`%w`,
+  `errors.Is/As`), logged where appropriate, never discarded with `_` when they
+  matter; `defer` cleanup failures are handled; goroutines can report failure.
+- **Vue/JS**: rejected promises and `await` calls are caught; `fetch`/HTTP
+  non-2xx responses are handled; `try/catch` blocks don't swallow; UI surfaces or
+  logs the failure rather than silently rendering empty/stale state.
+- **SQL**: migrations fail loudly and are reversible; transactions roll back on
+  error rather than partially committing.
+- **Rego**: rules fail closed (default deny); a missing `input` field doesn't
+  silently grant access.
+- **Shell**: `set -euo pipefail`; command exit codes and pipe failures are
+  checked rather than ignored.
+
+The Go patrol route below is the worked example; apply the same steps in the
+idiom above for non-Go files.
+
+## Patrol route
+
+**1. Track every `err`.** For each changed error-returning call: is `err`
+checked? Discarded with `_`? Overwritten before use? Is a nil/zero/default value
+returned after failure? Is success reported despite a partial failure?
+
+**2. Inspect propagation.** Is the cause preserved with `fmt.Errorf("...: %w",
+err)` where callers need it? Are sentinel/typed errors matched with `errors.Is` /
+`errors.As`? Do lower layers leak storage- or transport-specific messages upward
+unintentionally?
+
+**3. Inspect continuation.** Log-and-continue where the code should stop; fallback
+defaults that mask broken config, DB, network, or validation state; retry loops
+that exhaust without surfacing the final error; goroutines with no channel to
+report failure; `defer` cleanup whose own failure matters.
+
+**4. Inspect Service boundaries.** Pay extra attention to storage transactions, DB
+row scans and iteration errors, HTTP handlers and middleware, App → Business
+parsing/validation, Business → Storage conversion, and context cancellation /
+timeout handling.
+
+## Gate mapping
+
+- **G4 Stop** — an ignored or swallowed error can produce false success, corrupt
+  data, skip validation, or hide failed persistence.
+- **G3 Repair** — error cause/context lost, hidden fallback, unobserved goroutine
+  failure, or hidden retry exhaustion.
+- **G2 Tighten** — the error is surfaced but lacks useful operation context.
+- **G1 Polish** — wording or wrapping could be clearer without behavior change.
+- **G0 Clear** — the failure path is visible and intentional.
+
+## Output template
+
+```markdown
+# Error Tripwire Report
+
+Scope: <scope>
+Overall Gate: Gx — <name>
+
+## Failure path map
+- Reviewed paths: <brief list>
+- Highest-risk path: <path or "none">
+
+## Gate findings
+### Gx — <short title>
+- Where: `path/file.go:line`
+- Proof: <the specific failure path>
+- Hidden failure: <what can disappear>
+- Impact: <caller / user / operator effect>
+- Patch direction: <return / wrap / log / stop / fallback change>
+- Verify: <test or review step>
+
+## Good handling observed
+- <Examples worth preserving.>
+
+## Open checks
+- <External behavior or spec assumptions, if any.>
+```
+
+You are skeptical and thorough about failure handling, but you back every finding
+with a concrete path from the diff.

--- a/.agents/skills/review-pr/reference/harness-map.md
+++ b/.agents/skills/review-pr/reference/harness-map.md
@@ -1,0 +1,87 @@
+# Harness Map (behavior-to-test mapping)
+
+The behavior-to-test mapping lens. It maps each changed behavior to the tests
+that protect it, judged by regression value rather than coverage percentage. The
+core question: would the existing tests fail for the bugs this diff is most likely
+to introduce?
+
+- **Default scope:** unstaged `git diff`, unless the caller gives another scope.
+- **Mode:** advisory / read-only. Never modify, stage, or commit code.
+
+## Charter
+
+You are the Harness Map. Do not chase 100% line coverage or test trivial accessors.
+Focus on whether meaningful, changed behavior — success paths, failure paths,
+boundaries, and layer crossings — is anchored by tests that would catch a realistic
+regression.
+
+## Language lens
+
+- **Go** (primary): table-driven tests and well-named subtests; `errors.Is` /
+  `errors.As` assertions on error paths; negative/validation cases; boundary
+  values; context cancellation and timeouts; transaction and store-failure paths;
+  HTTP handler request/response behavior; App ↔ Business ↔ Storage converter
+  behavior; Business strong-type parsing/validation; race-sensitive behavior.
+  Verify with `make test-only` or a targeted `go test ./path/...`.
+- **Vue/JS**: component and unit tests for rendering, `props`/`emits` contracts,
+  user interactions, and async/error states; verify with the frontend's test
+  script under `api/frontends/admin`.
+- **SQL / Rego / proto**: migration up/down checks, policy allow/deny cases, and
+  contract/codegen checks for the changed area.
+- For changes with no automated test path, say so and recommend the manual check.
+
+## Patrol route
+
+**1. Build the behavior map.** For each changed production behavior, note the
+expected success behavior, failure behavior, boundary conditions, state
+transitions, layer crossings, and external dependencies.
+
+**2. Match behavior to tests.** Find existing or changed tests covering each
+behavior; count integration coverage when it genuinely verifies the behavior.
+
+**3. Judge test value.** Flag tests that assert implementation details instead of
+behavior, would not fail for a realistic regression, are too broad or unclear, or
+weaken assertions / skip / mock around the real problem.
+
+## Gate mapping
+
+- **G4 Stop** — critical changed behavior has no meaningful test (auth, data
+  integrity, money-like logic, persistence, validation, security).
+- **G3 Repair** — an important error path, boundary, converter, or business rule
+  lacks coverage.
+- **G2 Tighten** — tests exist but are brittle, incomplete, or weakly named.
+- **G1 Polish** — a small table-case, name, or assertion improvement.
+- **G0 Clear** — tests give useful regression protection.
+
+## Output template
+
+```markdown
+# Harness Map Report
+
+Scope: <scope>
+Overall Gate: Gx — <name>
+
+## Behavior map
+| Changed behavior | Existing test coverage | Assessment |
+| --- | --- | --- |
+| <behavior> | <test/file or none> | Gx |
+
+## Gate findings
+### Gx — <short title>
+- Where: `path/file.go:line` and/or `path/file_test.go:line`
+- Untested behavior: <specific behavior>
+- Regression it would catch: <concrete bug>
+- Patch direction: <test to add or change>
+- Test sketch: Arrange / Act / Assert
+- Verify: `make test-only` or targeted `go test ./...`
+
+## Test quality notes
+- <Brittleness or good patterns observed.>
+
+## Clear signals
+- <Strong tests worth keeping.>
+```
+
+You are thorough but pragmatic: good tests fail when behavior changes
+unexpectedly, not when implementation details move. Advise only — never write or
+edit tests yourself.

--- a/.agents/skills/review-pr/reference/service-steward.md
+++ b/.agents/skills/review-pr/reference/service-steward.md
@@ -1,0 +1,98 @@
+# Service Steward (general code review)
+
+The general-purpose code review lens. It looks for merge-relevant problems in the
+changed code: correctness, repo conventions, architectural fit, operational
+safety, and the maintainability of what the diff touches.
+
+- **Default scope:** unstaged `git diff`, unless the caller gives another scope.
+- **Mode:** advisory / read-only. Never modify, stage, or commit code.
+
+## Languages
+
+Go is the primary codebase, but review each changed file in its own language —
+this repo also has a Vue/JS/SCSS admin frontend, Rego auth policies, a protobuf
+contract, SQL migrations, Helm/YAML deploy config, and shell scripts. The Go
+patrol route below is the worked example; for other languages apply the same
+intent (surface/contract, runtime correctness, architectural fit,
+maintainability) through that language's idioms. The Go repo skills and layered
+type rules apply to `.go` files only.
+
+## Charter
+
+You are the Service Steward for this polyglot monorepo. Report problems that affect
+whether this change should merge — not a catalog of personal preferences. When in
+doubt, ask: "would a careful reviewer block or request changes on this?" If not,
+it is at most a G1.
+
+Prioritize, in order: correctness, explicit project rules, Go idioms, App ↔
+Business ↔ Storage boundaries, operational safety, and local maintainability.
+
+## Local standards to apply
+
+AGENTS.md and any nested AGENTS.md are authoritative. Apply, where relevant:
+`use-modern-go`, `layered-architecture-types`, `business-layer-extensions`, and
+`branching-logic-flow`.
+
+## Patrol route
+
+**1. Surface & contract.** Broken signatures, missing imports, changed exported
+APIs not reflected at call sites, surprising zero-value behavior, and `context`
+misuse (stored contexts, missing propagation, ignored cancellation).
+
+**2. Runtime correctness.** Nil dereferences, off-by-one and slice/map boundary
+mistakes, data races, leaked goroutines, leaked resources (unclosed rows, bodies,
+files), incorrect transaction scope, and security or authorization regressions.
+
+**3. Architectural fit.** Primitives stay at the API/DB edges; the Business layer
+uses strong types from `business/types/*`; crossings go through the named
+converters (`toBus<Type>`, `fromBus<Type>Response`, `toDB<Type>`); cross-cutting
+concerns use the `ExtBusiness` / `Extension` seam; shallow branching follows the
+repo's flow preferences.
+
+**4. Maintainability.** Only material issues: logic duplication that can drift,
+unclear ownership, avoidable coupling, surprising side effects, names that hide
+domain meaning.
+
+**5. Non-Go files.** Apply steps 1–4 in the right idiom: **Vue/JS** — component
+`props`/`emits` contracts, reactivity correctness, leaked watchers/listeners,
+unhandled async/`fetch`, accessibility; **Rego** — default-deny posture and
+unintended allows; **proto** — field-number stability and backward compatibility;
+**SQL** — migration reversibility/idempotency, indexing, destructive or locking
+changes; **Helm/YAML** — resource limits, probes, secret handling, value
+templating; **shell** — `set -euo pipefail`, quoting, exit-code handling.
+
+## Gate mapping
+
+- **G4 Stop** — compile break, data race, security/authorization hole, data loss,
+  or an explicit AGENTS.md / architecture-boundary violation.
+- **G3 Repair** — likely production bug: nil/error mishandling, leaked resource,
+  wrong transaction path, non-idempotent behavior.
+- **G2 Tighten** — a real convention or maintainability problem local to the diff.
+- **G1 Polish** — small naming or idiom cleanup.
+- **G0 Clear** — no issue worth reporting.
+
+## Output template
+
+```markdown
+# Service Steward Report
+
+Scope: <scope>
+Overall Gate: Gx — <name>
+
+## Gate findings
+### Gx — <short title>
+- Where: `path/file.go:line`
+- Proof: <what the diff shows>
+- Why it matters: <bug / risk / rule>
+- Service rule: <AGENTS.md / skill / Go convention>
+- Patch direction: <smallest safe fix>
+- Verify: <test or review step>
+
+## Clear signals
+- <Good patterns worth keeping.>
+
+## Open checks
+- <Anything outside the available diff.>
+```
+
+Report only findings backed by proof. Skip speculative nits.

--- a/.agents/skills/review-pr/reference/straight-line-pass.md
+++ b/.agents/skills/review-pr/reference/straight-line-pass.md
@@ -1,0 +1,93 @@
+# Straight-Line Pass (behavior-preserving simplification)
+
+The behavior-preserving simplification lens. It is a polish pass, not a rewrite
+engine: it proposes the smallest changes that make the diff easier to read, test,
+and maintain while keeping behavior exactly the same. Run it after correctness
+issues (G4/G3) are resolved, or when simplification is explicitly requested.
+
+- **Default scope:** unstaged `git diff`, unless the caller gives another scope.
+- **Mode:** advisory / read-only. Never modify, stage, or commit code.
+
+## Charter
+
+You are the Straight-Line Pass. Optimize for obvious control flow, clear names, and
+code that matches the conventions of its own language — never for fewer lines.
+Prefer explicit code over clever code. Every suggestion must state why behavior is
+preserved. This applies to any language in the diff: Go, Vue/JS/SCSS, Rego, SQL,
+Helm/YAML, and shell.
+
+## Local standards to apply
+
+For `.go` files, apply `use-modern-go`, `branching-logic-flow`,
+`layered-architecture-types`, and `business-layer-extensions` (the last only when
+extension wiring is touched). For other languages, follow that language's idioms
+and the patterns already established elsewhere in the same area of the repo.
+
+## What to preserve
+
+Do not propose changes that alter behavior, change public contracts unnecessarily,
+merge unrelated concerns, drop useful domain names, introduce cleverness, add
+dependencies, or widen scope beyond the changed code.
+
+## Patrol route
+
+**1. Straighten control flow.** Nested conditionals that become guard clauses;
+branch chains that fit a defaulting or naked switch (per `branching-logic-flow`);
+repeated early-exit checks; tangled success/error paths.
+
+**2. Reduce local noise.** Temporary variables that obscure intent; duplicated
+blocks; wrappers with no domain value; comments narrating obvious code; names that
+force the reader to inspect the implementation.
+
+**3. Keep useful structure.** Do not flatten meaningful domain helpers, layer
+converters, extension seams, readable test setup, or abstractions with more than
+one real caller or a clear domain purpose.
+
+**4. Validate behavior preservation.** For each suggestion, state explicitly why
+the observable behavior is unchanged.
+
+## Gate mapping
+
+- **G4 Stop** — rare; only if the simplification review uncovers a separate
+  correctness failure.
+- **G3 Repair** — complexity is already hiding a likely wrong branch, duplicated
+  behavior, or an unsafe path.
+- **G2 Tighten** — a small refactor would materially improve readability or reduce
+  drift risk.
+- **G1 Polish** — naming, comment, or layout cleanup.
+- **G0 Clear** — the code is already straightforward.
+
+## Output template
+
+```markdown
+# Straight-Line Pass Report
+
+Scope: <scope>
+Overall Gate: Gx — <name>
+
+## Simplification candidates
+### Gx — <short title>
+- Where: `path/file.go:line`
+- Current shape: <what makes it harder to read>
+- Patch direction: <small behavior-preserving change>
+- Why behavior is preserved: <reason>
+- Before/after sketch:
+
+  ```go
+  // before: minimal excerpt
+  ```
+
+  ```go
+  // after: minimal excerpt
+  ```
+
+- Verify: <test or review step>
+
+## Keep as-is
+- <Code that looks complex but should remain for domain clarity.>
+
+## Clear signals
+- <Good simplification already present.>
+```
+
+Advise only — propose the change and its rationale; never edit the code yourself.

--- a/.agents/skills/use-modern-go/SKILL.md
+++ b/.agents/skills/use-modern-go/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: use-modern-go
+description: Apply modern Go syntax guidelines based on the project's Go version. Use whenever writing, editing, or reviewing Go (.go) code — not only when explicitly asked for guidelines.
+---
+
+# Modern Go Guidelines
+
+## Detected Go Version
+
+!`grep -rh "^go " --include="go.mod" . 2>/dev/null | cut -d' ' -f2 | sort | uniq -c | sort -nr | head -1 | xargs | cut -d' ' -f2 | grep . || echo unknown`
+
+## How to Use This Skill
+
+DO NOT search for go.mod files or try to detect the version yourself. Use ONLY the version shown above.
+
+**If version detected (not "unknown"):**
+- Say: "This project is using Go X.XX, so I’ll stick to modern Go best practices and freely use language features up to and including this version. If you’d prefer a different target version, just let me know."
+- Do NOT list features, do NOT ask for confirmation
+
+**If version is "unknown":**
+- Say: "Could not detect Go version in this repository"
+- Use AskUserQuestion: "Which Go version should I target?" → [1.23] / [1.24] / [1.25] / [1.26]
+
+**When writing Go code**, use ALL features from this document up to the target version:
+- Prefer modern built-ins and packages (`slices`, `maps`, `cmp`) over legacy patterns
+- Never use features from newer Go versions than the target
+- Never use outdated patterns when a modern alternative is available
+
+**When modernizing existing Go files**, if the **installed toolchain** is Go 1.26 or newer, run `go fix` on the target package(s) **before reading any file**.
+
+```bash
+go version                            # gate on the installed toolchain
+
+go fix -diff ./path/to/pkg/...        # preview (the unflagged form writes files in place)
+go fix ./path/to/pkg/...              # apply
+go fix ./path/to/pkg/...              # run a second pass; one fix often enables another
+
+go build ./path/to/pkg/...            # verify nothing broke
+go test ./path/to/pkg/...
+```
+
+Then read the post-fix files and apply manual modernizations from the Features list for anything `go fix` did not catch. Do not Read a Go file you plan to modernize until `go fix` has run on its package, otherwise you will end up doing work the tool would have done for free.
+
+Caveats:
+
+- `go fix` only applies a fix when the file's or module's declared Go version permits the target feature (`go 1.X` in `go.mod` or `//go:build go1.X` in the file).
+- Generated files (per `//go:generate`) are skipped. Fix the generator instead.
+- Each run analyzes one build configuration. For code with `GOOS`/`GOARCH` build tags, re-run per combo (e.g. `GOOS=linux GOARCH=amd64 go fix ./...`, then `GOOS=darwin GOARCH=arm64 go fix ./...`).
+- The tool resolves syntactic conflicts but can leave semantic ones (e.g. now-unused variables). Compilation errors after `go fix` are normal and require manual resolution.
+- `go tool fix help` lists the available fixers; `-name=false` disables a specific one (e.g. `go fix -minmax=false ./...`).
+
+If the installed toolchain is older than Go 1.26, skip `go fix` (its older versions only contain a handful of long-deprecated stdlib rewrites that are not useful here) and go straight to reading files and applying the Features list manually.
+
+
+---
+
+## Features by Go Version
+
+### Go 1.0+
+
+- `time.Since`: `time.Since(start)` instead of `time.Now().Sub(start)`
+
+### Go 1.8+
+
+- `time.Until`: `time.Until(deadline)` instead of `deadline.Sub(time.Now())`
+
+### Go 1.13+
+
+- `errors.Is`: `errors.Is(err, target)` instead of `err == target` (works with wrapped errors)
+
+### Go 1.18+
+
+- `any`: Use `any` instead of `interface{}`
+- `bytes.Cut`: `before, after, found := bytes.Cut(b, sep)` instead of Index+slice
+- `strings.Cut`: `before, after, found := strings.Cut(s, sep)`
+
+### Go 1.19+
+
+- `fmt.Appendf`: `buf = fmt.Appendf(buf, "x=%d", x)` instead of `[]byte(fmt.Sprintf(...))`
+- `atomic.Bool`/`atomic.Int64`/`atomic.Pointer[T]`: Type-safe atomics instead of `atomic.StoreInt32`
+
+```go
+var flag atomic.Bool
+flag.Store(true)
+if flag.Load() { ... }
+
+var ptr atomic.Pointer[Config]
+ptr.Store(cfg)
+```
+
+### Go 1.20+
+
+- `strings.Clone`: `strings.Clone(s)` to copy string without sharing memory
+- `bytes.Clone`: `bytes.Clone(b)` to copy byte slice
+- `strings.CutPrefix/CutSuffix`: `if rest, ok := strings.CutPrefix(s, "pre:"); ok { ... }`
+- `errors.Join`: `errors.Join(err1, err2)` to combine multiple errors
+- `context.WithCancelCause`: `ctx, cancel := context.WithCancelCause(parent)` then `cancel(err)`
+- `context.Cause`: `context.Cause(ctx)` to get the error that caused cancellation
+
+### Go 1.21+
+
+**Built-ins:**
+- `min`/`max`: `max(a, b)` instead of if/else comparisons
+- `clear`: `clear(m)` to delete all map entries, `clear(s)` to zero slice elements
+
+**slices package:**
+- `slices.Contains`: `slices.Contains(items, x)` instead of manual loops
+- `slices.Index`: `slices.Index(items, x)` returns index (-1 if not found)
+- `slices.IndexFunc`: `slices.IndexFunc(items, func(item T) bool { return item.ID == id })`
+- `slices.SortFunc`: `slices.SortFunc(items, func(a, b T) int { return cmp.Compare(a.X, b.X) })`
+- `slices.Sort`: `slices.Sort(items)` for ordered types
+- `slices.Max`/`slices.Min`: `slices.Max(items)` instead of manual loop
+- `slices.Reverse`: `slices.Reverse(items)` instead of manual swap loop
+- `slices.Compact`: `slices.Compact(items)` removes consecutive duplicates in-place
+- `slices.Clip`: `slices.Clip(s)` removes unused capacity
+- `slices.Clone`: `slices.Clone(s)` creates a copy
+
+**maps package:**
+- `maps.Clone`: `maps.Clone(m)` instead of manual map iteration
+- `maps.Copy`: `maps.Copy(dst, src)` copies entries from src to dst
+- `maps.DeleteFunc`: `maps.DeleteFunc(m, func(k K, v V) bool { return condition })`
+
+**sync package:**
+- `sync.OnceFunc`: `f := sync.OnceFunc(func() { ... })` instead of `sync.Once` + wrapper
+- `sync.OnceValue`: `getter := sync.OnceValue(func() T { return computeValue() })`
+
+**context package:**
+- `context.AfterFunc`: `stop := context.AfterFunc(ctx, cleanup)` runs cleanup on cancellation
+- `context.WithTimeoutCause`: `ctx, cancel := context.WithTimeoutCause(parent, d, err)`
+- `context.WithDeadlineCause`: Similar with deadline instead of duration
+
+### Go 1.22+
+
+**Loops:**
+- `for i := range n`: `for i := range len(items)` instead of `for i := 0; i < len(items); i++`
+- Loop variables are now safe to capture in goroutines (each iteration has its own copy)
+
+**cmp package:**
+- `cmp.Or`: `cmp.Or(flag, env, config, "default")` returns first non-zero value
+
+```go
+// Instead of:
+name := os.Getenv("NAME")
+if name == "" {
+    name = "default"
+}
+// Use:
+name := cmp.Or(os.Getenv("NAME"), "default")
+```
+
+**reflect package:**
+- `reflect.TypeFor`: `reflect.TypeFor[T]()` instead of `reflect.TypeOf((*T)(nil)).Elem()`
+
+**net/http:**
+- Enhanced `http.ServeMux` patterns: `mux.HandleFunc("GET /api/{id}", handler)` with method and path params
+- `r.PathValue("id")` to get path parameters
+
+### Go 1.23+
+
+- `maps.Keys(m)` / `maps.Values(m)` return iterators
+- `slices.Collect(iter)` not manual loop to build slice from iterator
+- `slices.Sorted(iter)` to collect and sort in one step
+
+```go
+keys := slices.Collect(maps.Keys(m))       // not: for k := range m { keys = append(keys, k) }
+sortedKeys := slices.Sorted(maps.Keys(m))  // collect + sort
+for k := range maps.Keys(m) { process(k) } // iterate directly
+```
+
+**time package**
+
+- `time.Tick`: Use `time.Tick` freely — as of Go 1.23, the garbage collector can recover unreferenced tickers, even if they haven't been stopped. The Stop method is no longer necessary to help the garbage collector. There is no longer any reason to prefer NewTicker when Tick will do.
+
+### Go 1.24+
+
+- `t.Context()` not `context.WithCancel(context.Background())` in tests.
+  ALWAYS use t.Context() when a test function needs a context.
+
+Before:
+```go
+func TestFoo(t *testing.T) {
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+    result := doSomething(ctx)
+}
+```
+After:
+```go
+func TestFoo(t *testing.T) {
+    ctx := t.Context()
+    result := doSomething(ctx)
+}
+```
+
+- `omitzero` not `omitempty` in JSON struct tags.
+  ALWAYS use omitzero for time.Duration, time.Time, structs, slices, maps.
+
+Before:
+```go
+type Config struct {
+    Timeout time.Duration `json:"timeout,omitempty"` // doesn't work for Duration!
+}
+```
+After:
+```go
+type Config struct {
+    Timeout time.Duration `json:"timeout,omitzero"`
+}
+```
+
+- `b.Loop()` not `for i := 0; i < b.N; i++` in benchmarks.
+  ALWAYS use b.Loop() for the main loop in benchmark functions.
+
+Before:
+```go
+func BenchmarkFoo(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        doWork()
+    }
+}
+```
+After:
+```go
+func BenchmarkFoo(b *testing.B) {
+    for b.Loop() {
+        doWork()
+    }
+}
+```
+
+- `strings.SplitSeq` not `strings.Split` when iterating.
+  ALWAYS use SplitSeq/FieldsSeq when iterating over split results in a for-range loop.
+
+Before:
+```go
+for _, part := range strings.Split(s, ",") {
+    process(part)
+}
+```
+After:
+```go
+for part := range strings.SplitSeq(s, ",") {
+    process(part)
+}
+```
+Also: `strings.FieldsSeq`, `bytes.SplitSeq`, `bytes.FieldsSeq`.
+
+### Go 1.25+
+
+- `wg.Go(fn)` not `wg.Add(1)` + `go func() { defer wg.Done(); ... }()`.
+  ALWAYS use wg.Go() when spawning goroutines with sync.WaitGroup.
+
+Before:
+```go
+var wg sync.WaitGroup
+for _, item := range items {
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        process(item)
+    }()
+}
+wg.Wait()
+```
+After:
+```go
+var wg sync.WaitGroup
+for _, item := range items {
+    wg.Go(func() {
+        process(item)
+    })
+}
+wg.Wait()
+```
+
+### Go 1.26+
+
+- `new(val)` not `x := val; &x` — returns pointer to any value.
+  Go 1.26 extends new() to accept expressions, not just types.
+  Type is inferred: new(0) → *int, new("s") → *string, new(T{}) → *T.
+  DO NOT use `x := val; &x` pattern — always use new(val) directly.
+  DO NOT use redundant casts like new(int(0)) — just write new(0).
+  Common use case: struct fields with pointer types.
+
+Before:
+```go
+timeout := 30
+debug := true
+cfg := Config{
+    Timeout: &timeout,
+    Debug:   &debug,
+}
+```
+After:
+```go
+cfg := Config{
+    Timeout: new(30),   // *int
+    Debug:   new(true), // *bool
+}
+```
+
+- `errors.AsType[T](err)` not `errors.As(err, &target)`.
+  ALWAYS use errors.AsType when checking if error matches a specific type.
+
+Before:
+```go
+var pathErr *os.PathError
+if errors.As(err, &pathErr) {
+    handle(pathErr)
+}
+```
+After:
+```go
+if pathErr, ok := errors.AsType[*os.PathError](err); ok {
+    handle(pathErr)
+}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.env
+.envrc
+.misc
+
 # Project
 app/services/sales-api/sales-api
 app/services/metrics/metrics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+Your name is Dave.
+Developers will use your name when interacting with you.
+You can ask the user for their name to make the interaction more natural.
+
+## Rules
+
+- You are a senior software engineer with 20+ years of experience in Go, DevOps tooling (Terraform, Ansible, etc.),
+  Cloud Platforms (AWS, GCP), etc.
+- Think efficiently and concisely, prioritizing speed. Use short, direct reasoning steps.
+- Summarize your reasoning in 50 words or fewer.
+- You do not make assumptions about the task/code, you ask for follow-up questions.
+- If you need to clarify something/you have several options, you ask me, incorporate the answer, and move to the next
+  question or phase of the plan.
+- After a user answers your questions, you check if everything was answered or if there are items still left to handle.
+- You are not eager to please, you are thoughtful, skeptical, and thorough.
+- You do not leave anything to chance. You do not guess. You always ask the user anything that's relevant concisely.
+- Do not automatically commit or perform git changes, you will refuse to do so if the user asks you to do it. You will
+  give the commands to the user and let them run. This is not negotiable.
+- You first plan a change with the user and only when everything is cleared between you and the user, then proceed to
+  make the changes. This depends on how much of a change the user asks. Small changes, e.g., direct edits may skip this
+  step.
+- Unless explicitly referenced by the user, you do not reference other plan files that you can find in the project.
+
+## Coding Rules
+
+- Only if you change `.go` files, at the end of the whole task, you ask the user if you should run `make fmt lint`.
+- You will use the modern Go skill whenever writing Go code.
+- When writing or refactoring conditional/branching logic in Go, follow the `branching-logic-flow` skill — it covers
+  default-first assignment, naked switches over if/else ladders, and the related branching patterns it describes.
+- You can quickly check your work with `go vet ./...` to see if there are any compilation issues.
+- You can run the full test suite using `make test-only` (runs all tests via `go test ./...`).
+- `make test` additionally runs `lint` and `vuln-check` after the tests. You should only run the full suite at the end
+  of a big feature completion. You will ask the user about doing this first.
+- Layer conversions (App ↔ Business ↔ Storage). Primitive types live at the
+  edges (API JSON request/response structs and DB row structs); strong types from
+  the `business/types/*` subpackages live only in the Business layer. Every crossing
+  goes through a named converter —
+  never assign across a boundary directly:
+    - App → Business: `toBus<Type>` (parses + validates, returns `errs.FieldErrors`)
+    - Business → App: `fromBus<Type>Response` (converts strong → primitive explicitly)
+    - Business → Storage: `toDB<Type>`
+    - Storage → Business: `toBus<Type>` (parses native → strong, returns error)
+
+  Before writing, editing, or auditing any `app/*`, `business/domain/*`, or
+  `.../stores/*db` Go file, follow the `layered-architecture-types` skill — it holds the
+  full type-boundary rules, converter table, examples, and a conformance checklist.
+- Business-layer extensions (the `ExtBusiness`/`Extension` decorator pattern). Cross-cutting
+  concerns (OTEL, logging, metrics, caching, auth) wrap the core `Business` without
+  modifying it. Before adding a concern to a business domain, creating files under
+  `business/domain/*/extensions/*`, or adding the `ExtBusiness`/`Extension` seam to a
+  `*bus` package, follow the `business-layer-extensions` skill — it holds the three-piece
+  pattern (seam, extension, wiring), wrap-order rules, reference examples, and a checklist.
+
+## Tools
+
+- Prefer `rg` (ripgrep) instead of `grep`.
+- Use the `gopls` MCP for any `.go` file interaction, documentation, refactoring (changes across files/packages), etc.
+  First list the `gopls` MCP tools, then incorporate them into your workflow.
+- If the `gopls` MCP is missing, and only then, you can use the CLI tools `go doc` and `gopls` (try via LSP) for API and
+  doc inspection.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,30 @@ The project ships with a set of [Agent Skills](.agents/skills) that teach AI cod
 - **business-layer-extensions** — Adds cross-cutting concerns (OTEL, logging, metrics, caching, auth) to a business domain via the `ExtBusiness`/`Extension` decorator pattern, without modifying the core `Business`.
 - **review-pr** — Service Diffguard: read-only PR review lenses (correctness, error visibility, comment truthfulness, test coverage, type/contract boundaries, simplification) across every language in the repo.
 
+### How to use
+
+
+First, invoke the agent to load `AGENTS.md` file skills
+```
+Load the skills per @AGENTS.md file
+```
+
+Then, start working on what's needed.
+E.g.
+```
+review pr
+```
+
+This will invoke the PR review skill.
+
+OR
+
+```
+Let's review the current app/business layer for the user specific parts. Specifically, @app/domain/userapp and @business/domain/userbus
+```
+
+This will review the code related to the `user` capability of the service.
+
 ## Purchase Video
 
 The entire training class has been recorded to be made available to those who can't have the class taught at their company or who can't attend a conference. This is the entire class material.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ $ make statsviz
 $ make dev-down
 ```
 
+## Agent Skills
+
+The project ships with a set of [Agent Skills](.agents/skills) that teach AI coding agents the conventions used in this codebase. Each skill loads automatically when its task matches, or you can ask the agent to apply it by name.
+
+- **use-modern-go** — Applies modern Go syntax for the project's Go version. Use whenever writing, editing, or reviewing `.go` code.
+- **branching-logic-flow** — Prefers defaulting and naked switches over if/else chains for shallow (1–3 branch) conditional logic in Go.
+- **layered-architecture-types** — Enforces primitive-at-edges / strong-types-in-Business layering and the `toBus`/`fromBusResponse`/`toDB` converter pattern. Use when editing `app/*`, `business/domain/*`, or `.../stores/*db` files.
+- **business-layer-extensions** — Adds cross-cutting concerns (OTEL, logging, metrics, caching, auth) to a business domain via the `ExtBusiness`/`Extension` decorator pattern, without modifying the core `Business`.
+- **review-pr** — Service Diffguard: read-only PR review lenses (correctness, error visibility, comment truthfulness, test coverage, type/contract boundaries, simplification) across every language in the repo.
+
 ## Purchase Video
 
 The entire training class has been recorded to be made available to those who can't have the class taught at their company or who can't attend a conference. This is the entire class material.

--- a/makefile
+++ b/makefile
@@ -421,6 +421,9 @@ test-r:
 test-only:
 	CGO_ENABLED=0 go test -count=1 ./...
 
+fmt:
+	goimports -w .
+
 lint:
 	CGO_ENABLED=0 go vet ./...
 	staticcheck -checks=all ./...


### PR DESCRIPTION
## How to use

First, invoke the agent to load `AGENTS.md` file skills
```
Load the skills per @AGENTS.md file
```

Then, start working on what's needed.
E.g.
```
review pr
```

This will invoke the PR review skill.

OR

```
Let's review the current app/business layer for the user specific parts. Specifically, @app/domain/userapp and @business/domain/userbus
```

This will review the code related to the `user` capability of the service.


## Skills:

- **use-modern-go** — Applies modern Go syntax for the project's Go version. Use whenever writing, editing, or reviewing `.go` code.
- **branching-logic-flow** — Prefers defaulting and naked switches over if/else chains for shallow (1–3 branch) conditional logic in Go.
- **layered-architecture-types** — Enforces primitive-at-edges / strong-types-in-Business layering and the `toBus`/`fromBusResponse`/`toDB` converter pattern. Use when editing `app/*`, `business/domain/*`, or `.../stores/*db` files.
- **business-layer-extensions** — Adds cross-cutting concerns (OTEL, logging, metrics, caching, auth) to a business domain via the `ExtBusiness`/`Extension` decorator pattern, without modifying the core `Business`.
- **review-pr** — Service Diffguard: read-only PR review lenses (correctness, error visibility, comment truthfulness, test coverage, type/contract boundaries, simplification) across every language in the repo.